### PR TITLE
Dockerfileのリファクタリング

### DIFF
--- a/allographer.nimble
+++ b/allographer.nimble
@@ -13,6 +13,5 @@ skipDirs      = @["allographer/cli"]
 # Dependencies
 
 requires "nim >= 1.0.0"
-requires "bcrypt >= 0.2.1"
 requires "cligen >= 0.9.38"
 requires "progress >= 1.1.1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,8 @@ version: '3'
 services:
   allographer:
     build:
-      context: ./docker
-      dockerfile: app_Dockerfile
+      context: .
+      dockerfile: ./docker/app_Dockerfile
     tty: true
     environment:
       TZ: Asia/Tokyo

--- a/docker/app_Dockerfile
+++ b/docker/app_Dockerfile
@@ -19,7 +19,11 @@ RUN apk update && \
 RUN git config --global http.sslVerify false
 
 COPY . .
-RUN nimble install -y
+RUN nimble install -y && \
+    nimble install -y \
+           bcrypt \
+           coco \
+           ;
 
 ENV PATH $PATH:/root/.nimble/bin
 WORKDIR /home/www

--- a/docker/app_Dockerfile
+++ b/docker/app_Dockerfile
@@ -3,9 +3,18 @@ FROM nimlang/nim:alpine
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN apk update && \
     apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates openssl pcre bsd-compat-headers lcov \
-    sqlite mariadb-dev libpq && \
-    rm /usr/lib/mysqld* -fr && rm /usr/bin/mysql* -fr && \
+    apk add --no-cache \
+        ca-certificates \
+        openssl \
+        pcre \
+        bsd-compat-headers \
+        lcov \
+        sqlite \
+        mariadb-dev \
+        libpq \
+        && \
+    rm /usr/lib/mysqld* -fr && \
+    rm /usr/bin/mysql* -fr && \
     update-ca-certificates
 RUN git config --global http.sslVerify false
 RUN nimble install -y bcrypt cligen coco

--- a/docker/app_Dockerfile
+++ b/docker/app_Dockerfile
@@ -17,6 +17,9 @@ RUN apk update && \
     rm /usr/bin/mysql* -fr && \
     update-ca-certificates
 RUN git config --global http.sslVerify false
-RUN nimble install -y bcrypt cligen coco
+
+COPY . .
+RUN nimble install -y
+
 ENV PATH $PATH:/root/.nimble/bin
 WORKDIR /home/www

--- a/docker/app_Dockerfile
+++ b/docker/app_Dockerfile
@@ -4,14 +4,14 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositor
 RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache \
+        bsd-compat-headers \
         ca-certificates \
+        lcov \
+        libpq \
+        mariadb-dev \
         openssl \
         pcre \
-        bsd-compat-headers \
-        lcov \
         sqlite \
-        mariadb-dev \
-        libpq \
         && \
     rm /usr/lib/mysqld* -fr && \
     rm /usr/bin/mysql* -fr && \

--- a/docker/app_Dockerfile
+++ b/docker/app_Dockerfile
@@ -18,9 +18,7 @@ RUN apk update && \
     update-ca-certificates
 RUN git config --global http.sslVerify false
 
-COPY . .
-RUN nimble install -y && \
-    nimble install -y \
+RUN nimble install -y \
            bcrypt \
            coco \
            ;


### PR DESCRIPTION
* インストールするパッケージ順をソート
  * [Dockerfileのベストプラクティス](http://docs.docker.jp/engine/articles/dockerfile_best-practice.html#id6)より
* 依存パッケージのインストールをallographer.nimbleを使ってインストールするように変更
  * 依存パッケージを追加したときにDockerfileをいちいち修正しなくてよい