### PR TITLE
WIP: DocumentをMarkdownからreStructuredTextに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ let db = open(connection, user, password, database)
 
 
 ## Examples
-[Query Builder](./documents/query_builder.md)  
+[Query Builder](./documents/query_builder.rst)  
 [Schema Builder](./documents/schema_builder.md)  
 
 ## API Documents

--- a/documents/query_builder.rst
+++ b/documents/query_builder.rst
@@ -1,0 +1,107 @@
+======================
+Example: Query Builder
+======================
+
+`back <../README.md>`_
+
+.. contents:: Table of contents
+
+SELECT
+======
+
+When it returns following table
+
+==  =====  ====  ========================  ==== ========
+id  float  char  datetime                  null is_admin
+==  =====  ====  ========================  ==== ========
+1   3.14   char  2019-01-01 12:00:00.1234       1
+==  =====  ====  ========================  ==== ========
+
+Return JsonNode
+---------------
+
+.. code-block:: nim
+
+   import allographer/query_builder
+
+   echo RDB().table("test")
+       .select("id", "float", "char", "datetime", "null", "is_admin")
+       .get()
+
+.. code-block:: nim
+
+   >> @[
+     {
+       "id": 1,                                # JInt
+       "float": 3.14,                          # JFloat
+       "char": "char",                         # JString
+       "datetime": "2019-01-01 12:00:00.1234", # JString
+       "null": null                            # JNull
+       "is_admin": true                        # JBool
+     }
+   ]
+
+Return Object
+-------------
+
+If object is defined and set arg of get/getRaw/first/find, response will be object as ORM
+
+.. code-block:: nim
+
+   import allographer/query_builder
+
+   type Typ = ref object
+     id: int
+     float: float
+     char: string
+     datetime: string
+     null: string
+     is_admin: bool
+
+   var rows = RDB().table("test")
+             .select("id", "float", "char", "datetime", "null", "is_admin")
+             .get(Typ)
+
+.. code-block:: nim
+
+   echo rows[0].id
+   >> 1                            # int
+
+   echo rows[0].float
+   >> 3.14                         # float
+
+   echo rows[0].char
+   >> "char"                       # string
+
+   echo rows[0].datetime
+   >> "2019-01-01 12:00:00.1234"   # string
+
+   echo rows[0].null
+   >> ""                           # string
+
+   echo rows[0].is_admin
+   >> true                         # bool
+
+get
+----
+
+Retrieving all row from a table
+
+.. code-block:: nim
+
+   let users = RDB().table("users").get()
+   for user in users:
+     echo user["name"]
+
+first
+-----
+
+Retrieving a single row from a table
+
+.. code-block:: nim
+
+   let user = RDB()
+               .table("users")
+               .where("name", "=", "John")
+               .first()
+   echo user["name"]


### PR DESCRIPTION
MarkdownよりもreStructuredTextかAsciidocのほうが、
巨大なドキュメントを書く時に便利なので、そちらに変更しませんか？
という提案です。

ドキュメントの一部をreStructuredTextで書いてみました。  
https://github.com/jiro4989/nim-allographer/blob/chore/api-docs/documents/query_builder.rst#id5

reStructuredTextは目次を自動生成できるのと、目次までの相互リンクを貼れるので、
書く時にだいぶ楽できるかな、と。

Asciidocでも良かったのですが、Nimの公式ドキュメントはreStructuredTextで書かれているので
そちらに合わせた次第です。

ドキュメントを何で書くか、はリポジトリオーナーの意向に沿いたいと思うので、
Markdownのほうが好みでしたらこのPRは却下してもらえればと思います。

