### PR TITLE
masterブランチが更新されるとリリースドラフトを生成するアクションを追加

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,3 @@
+feature: feature/*
+bug: hotfix/*
+chore: chore/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -45,3 +45,15 @@ jobs:
         echo '' >> tests/config.nims
         echo 'switch("threads", "on")' >> tests/config.nims
         docker-compose run allographer nimble test
+
+  create-tag-draft:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    needs:
+      - build
+      - test-on-docker
+    steps:
+      - uses: release-drafter/release-drafter@v5.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,15 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3.1.0
+        with:
+          configuration-path: .github/pr-labeler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -138,3 +138,16 @@ let db = open(connection, user, password, database)
 [schema](https://itsumura-h.github.io/nim-allographer/schema_builder/schema.html)  
 [column](https://itsumura-h.github.io/nim-allographer/schema_builder/column.html)  
 [table](https://itsumura-h.github.io/nim-allographer/schema_builder/table.html)  
+
+## Development
+### Branch naming rule
+Please create this branch name when you will create a new pull request.
+
+| Branch | Description |
+| ------ | ----------- |
+| feature/*** | New feature branch |
+| hotfix/*** | Bug fix branch |
+| chore/*** | Chore work or maintenance |
+
+This naming rule automatically labels the pull request.
+


### PR DESCRIPTION
## 変更内容

* ルールに従ったブランチ名からPRにラベルを自動で付与するActionを追加
* PRに付与されているラベルからリリースドラフトを生成するActionを追加

自動でこんな感じのリリースが生成されるようになります。
https://github.com/jiro4989/websh/releases