### PR TITLE
fix .env file not find on Windows

### DIFF
--- a/src/allographer/baseEnv.nim
+++ b/src/allographer/baseEnv.nim
@@ -3,7 +3,7 @@ import dotenv
 
 for f in walkDir(getCurrentDir()):
   if f.path.contains(".env"):
-    let env = initDotEnv(getCurrentDir(), f.path.split("/")[^1])
+    let env = initDotEnv(getCurrentDir(), splitPath(f.path).tail)
     env.load()
     echo("used config file '", f.path, "'")
 


### PR DESCRIPTION
PS C:\Users\zhaoww\Desktop\kanban> c:\Users\zhaoww\Desktop\kanban\kanban.exe
C:\Users\zhaoww\.nimble\pkgs\allographer-0.18.0\allographer\baseEnv.nim(6) baseEnv
C:\Users\zhaoww\.nimble\pkgs\dotenv-1.1.1\dotenv.nim(35) initDotEnv
Error: unhandled exception: Path 'C:\Users\zhaoww\Desktop\kanban\C:\Users\zhaoww\Desktop\kanban\.env' does not exist [DotEnvPathError]