### PR TITLE
Fixes OS X library detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ First of all, add nim binary path
 ```sh
 export PATH=$PATH:~/.nimble/bin
 ```
-After install allographer, "dbtool" command is going to be available.  
+After install allographer, "dbtool" command is going to be available.
+
+If you get `SIGSEGV: Illegal storage access. (Attempt to read from nil?)` when trying to use the database you likely have a problem with the library path. On OS X the default is to check for the `brew --prefix` of the chosen driver, if that doesn't work it will look in `/usr/lib` or an environment variable `DYLD_xxx_PATH` where `xxx` if your driver: `SQLITE`, `MARIADB`, `MYSQL` or `POSTGRES`.
 
 ## Createing connection
 Database connection should be definded as singleton variable.
@@ -189,4 +191,3 @@ Please create this branch name when you will create a new pull request.
 | chore/*** | Chore work or maintenance |
 
 This naming rule automatically labels the pull request.
-

--- a/src/allographer/async/database/is_exists_lib.nim
+++ b/src/allographer/async/database/is_exists_lib.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/[os,strutils]
 
 func getOsName*():string =
   const f = staticRead("/etc/os-release")
@@ -9,9 +9,11 @@ func getOsName*():string =
 
 func isExistsSqlite*():bool =
   when defined(macosx):
-    const query = "ldconfig -p | grep libsqlite3.dylib" # TODO
+    const query = "brew --prefix sqlite"
     const res = gorgeEx(query)
-    return res.exitCode == 0 and res.output.len > 0
+    if res.exitCode == 0: return true
+    const libPath = os.getEnv("DYLD_SQLITE_PATH", "/usr/lib/sqlite3.dylib")
+    return fileExists( libPath )
   elif defined(linux) or defined(bsd):
     const osName = getOsName()
     when osName == "alpine":
@@ -28,9 +30,11 @@ func isExistsSqlite*():bool =
 
 func isExistsMysql*():bool =
   when defined(macosx):
-    const query = "ldconfig -p | grep libmysqlclient.dylib" # TODO
+    const query = "brew --prefix mysql"
     const res = gorgeEx(query)
-    return res.exitCode == 0 and res.output.len > 0
+    if res.exitCode == 0: return true
+    const libPath = os.getEnv("DYLD_MYSQL_PATH", "/usr/lib/libmysqlclient.dylib")
+    return fileExists( libPath )
   elif defined(linux) or defined(bsd):
     const osName = getOsName()
     if osName == "alpine":
@@ -45,9 +49,11 @@ func isExistsMysql*():bool =
 
 func isExistsMariadb*():bool =
   when defined(macosx):
-    const query = "ldconfig -p | grep libmariadb.dylib" # TODO
+    const query = "brew --prefix mariadb"
     const res = gorgeEx(query)
-    return res.exitCode == 0 and res.output.len > 0
+    if res.exitCode == 0: return true
+    const libPath = os.getEnv("DYLD_MARIADB_PATH", "/usr/lib/libmariadb.dylib")
+    return fileExists( libPath )
   elif defined(linux) or defined(bsd):
     const osName = getOsName()
     if osName == "alpine":
@@ -64,9 +70,11 @@ func isExistsMariadb*():bool =
 
 func isExistsPostgres*():bool =
   when defined(macosx):
-    const query = "ldconfig -p | grep libpq.dylib" # TODO
+    const query = "brew --prefix postgres"
     const res = gorgeEx(query)
-    return res.exitCode == 0 and res.output.len > 0
+    if res.exitCode == 0: return true
+    const libPath = os.getEnv("DYLD_POSTGRES_PATH", "/usr/lib/libpq.dylib")
+    return fileExists( libPath )
   elif defined(linux) or defined(bsd):
     const osName = getOsName()
     if osName == "alpine":


### PR DESCRIPTION
Attempts to fix the library detection. Since most users are likely to be using brew I default to that. If no prefix is available for the chosen driver I look in /usr/lib and give an ENV var escape hatch.

This solved #176 for me. Strangely the actual value from the library detection is never used and I could probably have solved my issue by just statically returning `true` instead ...

In any case this is better than what was there since `ldconfig` doesn't even ship with OS X, at least not any more...