### PR TITLE
Feature #223 - Support strings in where(Not)In clauses

### DIFF
--- a/src/allographer/query_builder/generators.nim
+++ b/src/allographer/query_builder/generators.nim
@@ -183,6 +183,8 @@ proc whereInSql*(self:Rdb): Rdb =
           widthString.add($(val.getInt()))
         elif val.kind == JFloat:
           widthString.add($(val.getFloat()))
+        elif val.kind == JString:
+          widthString.add(&"'{val.getStr()}'")
 
       if self.sqlString.contains("WHERE"):
         self.sqlString.add(&" AND {column} IN ({widthString})")
@@ -203,6 +205,8 @@ proc whereNotInSql*(self:Rdb): Rdb =
           widthString.add($(val.getInt()))
         elif val.kind == JFloat:
           widthString.add($(val.getFloat()))
+        elif val.kind == JString:
+          widthString.add(&"'{val.getStr()}'")
 
       if self.sqlString.contains("WHERE"):
         self.sqlString.add(&" AND {column} NOT IN ({widthString})")

--- a/src/allographer/query_builder/grammars.nim
+++ b/src/allographer/query_builder/grammars.nim
@@ -246,7 +246,7 @@ proc whereNotBetween*(self:Rdb, column:string, width:array[2, string]): Rdb =
     })
   return self
 
-proc whereIn*(self:Rdb, column:string, width:seq[int|float]): Rdb =
+proc whereIn*(self:Rdb, column:string, width:seq[int|float|string]): Rdb =
   if self.query.hasKey("where_in") == false:
     self.query["where_in"] = %*[{
       "column": column,
@@ -260,7 +260,7 @@ proc whereIn*(self:Rdb, column:string, width:seq[int|float]): Rdb =
   return self
 
 
-proc whereNotIn*(self:Rdb, column:string, width:seq[int|float]): Rdb =
+proc whereNotIn*(self:Rdb, column:string, width:seq[int|float|string]): Rdb =
   if self.query.hasKey("where_not_in") == false:
     self.query["where_not_in"] = %*[{
       "column": column,

--- a/tests/test_query.nim
+++ b/tests/test_query.nim
@@ -317,6 +317,15 @@ for rdb in dbConnections:
                 .await
         echo t
         check t[0]["name"].getStr() == "user5"
+        
+        t = rdb
+                .table("user")
+                .select("id", "name")
+                .whereBetween("id", [4, 10])
+                .whereIn("name", @["user5", "user6", "user7"])
+                .get()
+                .await
+        check t[0]["name"].getStr() == "user5"
         rdb.raw("ROLLBACK").exec().await
 
     test("whereNotInTest"):
@@ -327,6 +336,21 @@ for rdb in dbConnections:
                 .select("id", "name")
                 .whereBetween("id", [4, 10])
                 .whereNotIn("id", @[5, 6, 7])
+                .get()
+                .await
+        echo t
+        check t == @[
+          %*{"id":4, "name": "user4"},
+          %*{"id":8, "name": "user8"},
+          %*{"id":9, "name": "user9"},
+          %*{"id":10, "name": "user10"},
+        ]
+        
+        t = rdb
+                .table("user")
+                .select("id", "name")
+                .whereBetween("id", [4, 10])
+                .whereNotIn("name", @["user5", "user6", "user7"])
                 .get()
                 .await
         echo t


### PR DESCRIPTION
Allow strings when using `whereIn` and `whereNotIn`

Closes #223 