### PR TITLE
require db_connector for nim > 1.6

### DIFF
--- a/allographer.nimble
+++ b/allographer.nimble
@@ -14,6 +14,8 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.2.0"
+when (NimMajor, NimMinor) > (1, 6):
+  requires "db_connector"
 
 import strformat, os
 


### PR DESCRIPTION
Update nimble file to require db_connector for nim-devel. The nim file which imports it has already been updated.