### PR TITLE
fix `getOsName` on `macosx`

### DIFF
--- a/src/allographer/utils.nim
+++ b/src/allographer/utils.nim
@@ -1,0 +1,13 @@
+import strutils
+
+func getOsName*():string =
+  when defined(linux) or defined(bsd):
+    const f = staticRead("/etc/os-release")
+    for row in f.split("\n"):
+      let kv = row.split("=")
+      if kv[0] == "ID":
+        return kv[1]
+  elif defined(windows):
+    return "windows"
+  else:
+    return ""

--- a/src/allographer/v1/query_builder/libs/mysql/mysql_rdb.nim
+++ b/src/allographer/v1/query_builder/libs/mysql/mysql_rdb.nim
@@ -1,16 +1,4 @@
-import strutils
-
-func getOsName*():string =
-  when defined(macosx) or defined(linux) or defined(bsd):
-    const f = staticRead("/etc/os-release")
-    for row in f.split("\n"):
-      let kv = row.split("=")
-      if kv[0] == "ID":
-        return kv[1]
-  elif defined(windows):
-    return "windows"
-  else:
-    return ""
+import ../../../../utils
 
 {.push, callconv: cdecl.}
 when defined(nimHasStyleChecks):

--- a/src/allographer/v2/query_builder/libs/mariadb/mariadb_rdb.nim
+++ b/src/allographer/v2/query_builder/libs/mariadb/mariadb_rdb.nim
@@ -1,16 +1,4 @@
-import strutils
-
-func getOsName*():string =
-  when defined(macosx) or defined(linux) or defined(bsd):
-    const f = staticRead("/etc/os-release")
-    for row in f.split("\n"):
-      let kv = row.split("=")
-      if kv[0] == "ID":
-        return kv[1]
-  elif defined(windows):
-    return "windows"
-  else:
-    return ""
+import ../../../../utils
 
 {.push, callconv: cdecl.}
 when defined(nimHasStyleChecks):

--- a/src/allographer/v2/query_builder/libs/mysql/mysql_rdb.nim
+++ b/src/allographer/v2/query_builder/libs/mysql/mysql_rdb.nim
@@ -1,16 +1,4 @@
-import strutils
-
-func getOsName*():string =
-  when defined(macosx) or defined(linux) or defined(bsd):
-    const f = staticRead("/etc/os-release")
-    for row in f.split("\n"):
-      let kv = row.split("=")
-      if kv[0] == "ID":
-        return kv[1]
-  elif defined(windows):
-    return "windows"
-  else:
-    return ""
+import ../../../../utils
 
 {.push, callconv: cdecl.}
 when defined(nimHasStyleChecks):


### PR DESCRIPTION
the `getOsName` function only used on linux system and `macosx` has no "/etc/os-release"