### PR TITLE
311-fix-create-schema-test

### DIFF
--- a/src/allographer/schema_builder/usecases/mariadb/create_schema.nim
+++ b/src/allographer/schema_builder/usecases/mariadb/create_schema.nim
@@ -76,9 +76,21 @@ proc generateSchemaCode(tablesInfo: Table[string, seq[tuple[name: string, typ: s
   return code
 
 proc createSchema*(rdb: MariaDBConnections, schemaPath="") {.async.} =
-  ## create schema.nim
-  let tablesInfo = await rdb.getTableInfo()
-  let schemaCode = generateSchemaCode(tablesInfo)
+  ## if schemaPath is not specified, the schema will be generated in the current directory
+  ## 
+  ## Default schema file name is `getCurrentDir() / "schema.nim"`
+  try:
+    let tablesInfo = rdb.getTableInfo().await
+    let schemaCode = generateSchemaCode(tablesInfo)
 
-  writeFile(schemaPath / "schema.nim", schemaCode)
-  echo "schema.nim generated successfully"
+    let schemaFilePath =
+      if schemaPath == "":
+        getCurrentDir() / "schema.nim"
+      else:
+        schemaPath
+    
+    writeFile(schemaFilePath, schemaCode)
+    echo "schema generated successfully in ", schemaFilePath
+  except Exception as e:
+    echo "Error generating schema: ", e.msg
+    raise

--- a/src/allographer/schema_builder/usecases/surreal/create_schema.nim
+++ b/src/allographer/schema_builder/usecases/surreal/create_schema.nim
@@ -78,14 +78,21 @@ proc generateSchemaCode(tablesInfo: Table[string, seq[tuple[name: string, typ: s
 
 
 proc createSchema*(rdb: SurrealConnections, schemaPath="") {.async.} =
-  ## create schema.nim
+  ## if schemaPath is not specified, the schema will be generated in the current directory
+  ## 
+  ## Default schema file name is `getCurrentDir() / "schema.nim"`
   try:
-    let tablesInfo = await rdb.getTableInfo()
+    let tablesInfo = rdb.getTableInfo().await
     let schemaCode = generateSchemaCode(tablesInfo)
+
+    let schemaFilePath =
+      if schemaPath == "":
+        getCurrentDir() / "schema.nim"
+      else:
+        schemaPath
     
-    writeFile(schemaPath / "schema.nim", schemaCode)
-    echo "schema.nim generated successfully"
-    
+    writeFile(schemaFilePath, schemaCode)
+    echo "schema generated successfully in ", schemaFilePath
   except Exception as e:
     echo "Error generating schema: ", e.msg
     raise

--- a/tests/mariadb/test_create_schema.nim
+++ b/tests/mariadb/test_create_schema.nim
@@ -2,6 +2,8 @@ discard """
   cmd: "nim c -d:reset $file"
 """
 
+# nim c -d:reset -r tests/mariadb/test_create_schema.nim
+
 import std/unittest
 import std/asyncdispatch
 import std/os
@@ -14,6 +16,7 @@ import ../clear_tables
 
 let rdb = mariadb
 let schemaFilePath = getCurrentDir() / "schema.nim"
+clearTables(rdb).waitFor()
 
 suite "Schema output after migration":
   setup:
@@ -61,7 +64,7 @@ suite "Schema output after migration":
 
   test "should generate schema.nim file":
     # スキーマ生成
-    rdb.createSchema().waitFor()
+    rdb.createSchema(schemaFilePath).waitFor()
     
     # schema.nim ファイルの存在確認
     check fileExists(schemaFilePath)

--- a/tests/mysql/test_create_schema.nim
+++ b/tests/mysql/test_create_schema.nim
@@ -2,6 +2,8 @@ discard """
   cmd: "nim c -d:reset $file"
 """
 
+# nim c -d:reset -r tests/mysql/test_create_schema.nim
+
 import std/unittest
 import std/asyncdispatch
 import std/os
@@ -14,6 +16,7 @@ import ../clear_tables
 
 let rdb = mysql
 let schemaFilePath = getCurrentDir() / "schema.nim"
+clearTables(rdb).waitFor()
 
 suite "Schema output after migration":
   setup:
@@ -61,7 +64,7 @@ suite "Schema output after migration":
 
   test "should generate schema.nim file":
     # スキーマ生成
-    rdb.createSchema().waitFor()
+    rdb.createSchema(schemaFilePath).waitFor()
     
     # schema.nim ファイルの存在確認
     check fileExists(schemaFilePath)

--- a/tests/surrealdb/test_create_schema.nim
+++ b/tests/surrealdb/test_create_schema.nim
@@ -2,6 +2,8 @@ discard """
   cmd: "nim c -d:reset $file"
 """
 
+# nim c -d:reset -r tests/surrealdb/test_create_schema.nim
+
 import std/unittest
 import std/asyncdispatch
 import std/os
@@ -14,6 +16,7 @@ import ../clear_tables
 
 let rdb = surreal
 let schemaFilePath = getCurrentDir() / "schema.nim"
+clearTables(rdb).waitFor()
 
 suite "Schema output after migration":
   setup:
@@ -60,7 +63,7 @@ suite "Schema output after migration":
 
   test "should generate schema.nim file":
     # スキーマ生成
-    rdb.createSchema().waitFor()
+    rdb.createSchema(schemaFilePath).waitFor()
     
     # schema.nim ファイルの存在確認
     check fileExists(schemaFilePath)


### PR DESCRIPTION
Refactor schema generation to allow custom schema file paths and improve error handling

- Update createSchema procedures for MariaDB, MySQL, and Surreal to accept an optional schemaPath parameter.
- If no path is provided, use the current directory with "schema.nim" as the default file name.
- Wrap schema generation logic in try/except blocks to capture and report detailed errors.
- Update tests to clear tables and pass the explicit schema file path.