### PR TITLE
docs: mark SurrealDB as planned for v3 and update README/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ allographer
 
 
 An asynchronous query builder library inspired by [Laravel/PHP](https://readouble.com/laravel/6.0/en/queries.html) and [Orator/Python](https://orator-orm.com) for Nim.  
-Supported Databases are [Sqlite3](https://www.sqlite.org/index.html), [PostgreSQL](https://www.postgresql.org/), [MySQL](https://www.mysql.com/), [MariaDB](https://mariadb.org/) and [SurrealDB](https://surrealdb.com/).  
-Supported Nim for both `1.6.14` and `2.0.0`
+Supported Databases are [Sqlite3](https://www.sqlite.org/index.html), [PostgreSQL](https://www.postgresql.org/), [MySQL](https://www.mysql.com/) and [MariaDB](https://mariadb.org/). (SurrealDB is planned to be supported in v3)  
+Supported Nim v2
 
 ## Easy to access Rdb
 ### Query Builder
@@ -119,7 +119,8 @@ nimble install allographer
 If you get `SIGSEGV: Illegal storage access. (Attempt to read from nil?)` when trying to use the database you likely have a problem with the library path. On OS X the default is to check for the `brew --prefix` of the chosen driver, if that doesn't work it will look in `/usr/lib` or an environment variable `DYLD_xxx_PATH` where `xxx` if your driver: `SQLITE`, `MARIADB`, `MYSQL` or `POSTGRES`.
 
 ## Configuation
-Allographer loads emvironment variables of `DB_SQLITE`, `DB_POSTGRES`, `DB_MYSQL` `DB_MARIADB` and `DB_SURREAL` to define which process should be **compiled**.<br>
+Allographer loads emvironment variables of `DB_SQLITE`, `DB_POSTGRES`, `DB_MYSQL` and `DB_MARIADB` to define which process should be **compiled**.<br>
+(`DB_SURREAL` is planned to be supported in v3)<br>
 These environment variables have to be set at compile time, so they have to be written in `config.nims` not in `.env`.
 
 config.nims
@@ -145,7 +146,7 @@ let sqliteRdb* = dbOpen(Sqlite3, "/path/to/db/sqlite3.db", maxConnections=maxCon
 let mysqlRdb* = dbOpen(MySQL, "database", "user", "password", "localhost", 3306, maxConnections, timeout)
 let mariaRdb* = dbOpen(MariaDB, "database", "user", "password", "localhost", 3306, maxConnections, timeout)
 let pgUrlRdb* = dbOpen(PostgreSQL, databaseUrl = asDatabaseUrl("postgresql://user:password@localhost:5432/database"), maxConnections=maxConnections, timeout=timeout)
-let surrealDb* = dbOpen(SurrealDb, "test_ns" "test_db", "user", "password" "http://localhost", 8000, maxConnections, timeout)
+# let surrealDb* = dbOpen(SurrealDb, "test_ns" "test_db", "user", "password" "http://localhost", 8000, maxConnections, timeout) # planned for v3
 ```
 
 Then, call connection when you run query.
@@ -177,8 +178,8 @@ proc dbOpen*(driver:Driver, database:string="", user:string="", password:string=
 ## Documents
 [Schema Builder for RDB](./documents/rdb/schema_builder.md)  
 [Query Builder for RDB](./documents/rdb/query_builder.md)  
-[Schema Builder for SurrealDB](./documents/surrealdb/schema_builder.md)  
-[Query Builder for SurrealDB](./documents/surrealdb/query_builder.md)  
+[Schema Builder for SurrealDB](./documents/surrealdb/schema_builder.md) (planned for v3)  
+[Query Builder for SurrealDB](./documents/surrealdb/query_builder.md) (planned for v3)
 
 
 ## Nim API Documents

--- a/documents/rdb/schema_builder.md
+++ b/documents/rdb/schema_builder.md
@@ -238,8 +238,7 @@ Column.strForeign("uuid")
   .onTable("users")
   .onDelete(SET_NULL)
 
-# use `on("users")` in Nim v1
-# use `onTable("users")` in Nim v2
+# use `onTable("users")`
 ```
 
 arg of `onDelete` is enum

--- a/documents/rdb/surreal_efficiency_report.md
+++ b/documents/rdb/surreal_efficiency_report.md
@@ -1,4 +1,6 @@
 # Surreal driver 効率改善レポート
+> [!WARNING]
+> SurrealDB support is planned for v3. The current implementation and proposed improvements are for reference only and will be addressed in v3.
 
 `src/allographer/query_builder/libs/surreal/` と、その呼び出し元である `models/surreal/` を調査し、`documents/rdb/postgres_efficiency_report.md` と `320-allographerpostgresql-非同期待機改善-設計書.mdc` と同じ観点で、処理効率と待機制御の改善余地を整理した。
 

--- a/documents/surrealdb/query_builder.md
+++ b/documents/surrealdb/query_builder.md
@@ -1,5 +1,8 @@
 Example: Query Builder for SurrealDB
 ===
+> [!WARNING]
+> SurrealDB support is planned for v3. The current implementation is for reference only and may not work as expected in v2.
+
 [back](../../README.md)
 
 ## index

--- a/documents/surrealdb/schema_builder.md
+++ b/documents/surrealdb/schema_builder.md
@@ -1,5 +1,8 @@
 Example: Schema Builder for SurrealDB
 ===
+> [!WARNING]
+> SurrealDB support is planned for v3. The current implementation is for reference only and may not work as expected in v2.
+
 [back](../../README.md)
 
 ## index


### PR DESCRIPTION
- Remove SurrealDB from the supported databases list and mark it as planned for v3.
- Simplify supported Nim version to v2 and comment out the SurrealDB dbOpen example.
- Clarify usage of `onTable` in schema docs.
- Add warning banners to SurrealDB-related documentation and the efficiency report indicating the feature is planned for v3.