### PR TITLE
Unify pool-timeout behavior and add prepared-statement reuse for Post…

### DIFF
--- a/.cursor/rules/branch/fix.mdc
+++ b/.cursor/rules/branch/fix.mdc
@@ -1,0 +1,35 @@
+---
+description: fixブランチでの開発時に読み込む
+alwaysApply: false
+---
+fix ブランチルール
+===
+
+
+allographer自体の改善
+
+- `getFreeConn` がタイムアウトすると `errorConnectionNum` を返すが、その後の `getRowPlain` / `exec` / `getAllRows` は例外ではなくそのまま `return` している。結果として、更新できていなくてもアプリ側では成功レスポンスを返せてしまう。
+- prepared statement は接続ごとに lazy prepare されるが、プール単位の cache がない。高頻度 SQL が複数接続に散ると、prepare の局所性が弱い。
+- `close()` は使った接続全てに `DEALLOCATE` を送る実装なので、短寿命の prepared statement を多用すると warm 状態を毎回捨てる。
+- DML 実行時の列型取得は現在は table 単位 cache になっているが、bulk update 用の raw SQL / prepared SQL を多用する場合は、そもそも query builder を通さない高速経路の価値が高い。
+
+改善方針:
+- `errorConnectionNum` に到達したときは no-op ではなく `DbError` を投げる。silent failure は benchmark だけでなく通常アプリでも危険。
+- `Connections` に SQL 単位の prepared cache を持たせ、同一 SQL の physical prepare を接続ごとに 1 回へ寄せる。
+- `close()` は論理 close に寄せ、物理 `DEALLOCATE` は明示 API に分離する。steady-state の benchmark では prepared state を維持できるようにする。
+- 接続固定 API、あるいは transaction / prepared context を足し、同一 logical operation の複数クエリを同じ接続に寄せられるようにする。
+- bulk update 用に `raw(...).exec()` だけでなく、prepared raw SQL を再利用できる経路を整える。今回のベンチマーク用途では query builder の汎用性よりも固定 SQL の再利用性が効く。
+
+## 進捗
+- [x] `errorConnectionNum` 到達時の silent return を `DbError` へ置換（PostgreSQL / MySQL / MariaDB / SQLite）
+- [x] PostgreSQL に SQL 単位の prepared cache (`Connections.preparedCache`) を追加
+- [x] PostgreSQL prepared `close()` を論理 close 化し、`flushStmt(sql)` / `clearStmtCache()` を追加
+- [x] PostgreSQL に `withConn` / `PostgresPreparedContext` を追加し、prepared `first/get/exec` の `ctx` overload を追加
+- [x] `example/benchmark.nim` を prepared cold/warm 計測へ分離し、warm 側で statement 再利用経路を追加
+- [x] PostgreSQL prepared statement テストに論理 close / cache clear / prepared context ケースを追加
+- [x] pool wait テストに pool size 0 時の `DbError` 検証を追加（PostgreSQL / MariaDB / SQLite）
+
+## 調査結果・設計まとめ
+- `errorConnectionNum` の no-op return は、DML 失敗を呼び出し側が検知できないため、全 RDB driver で同じ失敗モードを発生させていた。今回 `DbError` へ統一し、失敗を上位へ伝播させる。
+- prepared cache はまず PostgreSQL に導入した。理由は `PREPARE/DEALLOCATE` のネットワーク往復コストがベンチで支配的だったため。
+- `close()` の意味を「ハンドルの寿命」と「物理 prepared state の寿命」で分離し、warm 計測で state を保持できるようにした。

--- a/documents/rdb/query_builder.md
+++ b/documents/rdb/query_builder.md
@@ -33,6 +33,7 @@ Example: Query Builder for RDB
    * [DELETE](#delete)
    * [Plain Response](#plain-response)
    * [Raw SQL](#raw-sql)
+   * [Prepared Statement](#prepared-statement)
    * [Aggregates](#aggregates)
    * [Transaction](#transaction)
 
@@ -666,6 +667,40 @@ echo rdb.raw(sql).firstPlain().await
 ```nim
 let sql = "UPDATE users SET name = ? where id = ?"
 rdb.raw(sql, "John", "1").exec().await
+```
+
+## Prepared Statement
+[to index](#index)
+
+```nim
+import allographer/query_builder
+
+let selectStmt = rdb.prepare("""SELECT "id", "name" FROM "users" WHERE "id" = ?""")
+let updateStmt = rdb.prepare("""UPDATE "users" SET "name" = ? WHERE "id" = ?""")
+
+let row = await selectStmt.first(@["1"])
+await updateStmt.exec(@["John", "1"])
+
+# close() is logical close.
+await selectStmt.close()
+await updateStmt.close()
+```
+
+In PostgreSQL, a context API can be used to ensure multiple operations use the same connection.
+
+```nim
+await rdb.withConn(
+  proc(ctx: PostgresPreparedContext): Future[void] {.async.} =
+    discard await selectStmt.first(ctx, @["1"])
+    await updateStmt.exec(ctx, @["John", "1"])
+)
+```
+
+In PostgreSQL, APIs to physically clear the prepared statement cache are also available.
+
+```nim
+await rdb.flushStmt("""SELECT "id", "name" FROM "users" WHERE "id" = ?""")
+await rdb.clearStmtCache()
 ```
 
 ## Aggregates

--- a/example/benchmark.nim
+++ b/example/benchmark.nim
@@ -79,30 +79,61 @@ template benchmarkScenario(rdb: untyped, useBackticks: static[bool]): untyped =
     await all(futures)
     return response
 
-  proc benchUpdatePrepared(): Future[seq[JsonNode]] {.async.} =
+  when compiles(rdb.prepare("SELECT 1")):
     when isExistsMariaDB or isExistsMySQL:
-      let selectSql = """SELECT `index` as id, `randomNumber` FROM `World` WHERE `index` = ?"""
-      let updateSql = """UPDATE `World` SET `randomNumber` = ? WHERE `index` = ?"""
+      const selectSql = """SELECT `index` as id, `randomNumber` FROM `World` WHERE `index` = ?"""
+      const updateSql = """UPDATE `World` SET `randomNumber` = ? WHERE `index` = ?"""
     else:
-      let selectSql = """SELECT "index" as id, "randomNumber" FROM "World" WHERE "index" = ?"""
-      let updateSql = """UPDATE "World" SET "randomNumber" = ? WHERE "index" = ?"""
+      const selectSql = """SELECT "index" as id, "randomNumber" FROM "World" WHERE "index" = ?"""
+      const updateSql = """UPDATE "World" SET "randomNumber" = ? WHERE "index" = ?"""
 
-    let selectStmt = rdb.prepare(selectSql)
-    let updateStmt = rdb.prepare(updateSql)
-    var response = newSeq[JsonNode](countNum)
-    var futures = newSeq[Future[void]](countNum)
-    for i in 1..countNum:
-      let index = rand(range1_10000)
-      let number = rand(range1_10000)
-      futures[i - 1] = (proc(): Future[void] {.async.} =
-        discard await selectStmt.first(@[$index])
-        await updateStmt.exec(@[$number, $index])
-      )()
-      response[i - 1] = %*{"id": index, "randomNumber": number}
-    await all(futures)
-    await selectStmt.close()
-    await updateStmt.close()
-    return response
+    proc benchUpdatePreparedCold(): Future[seq[JsonNode]] {.async.} =
+      let selectStmt = rdb.prepare(selectSql)
+      let updateStmt = rdb.prepare(updateSql)
+      var response = newSeq[JsonNode](countNum)
+      var futures = newSeq[Future[void]](countNum)
+      for i in 1..countNum:
+        let index = rand(range1_10000)
+        let number = rand(range1_10000)
+        futures[i - 1] = (proc(): Future[void] {.async.} =
+          discard await selectStmt.first(@[$index])
+          await updateStmt.exec(@[$number, $index])
+        )()
+        response[i - 1] = %*{"id": index, "randomNumber": number}
+      await all(futures)
+      await selectStmt.close()
+      await updateStmt.close()
+      return response
+
+    let selectStmtWarm = rdb.prepare(selectSql)
+    let updateStmtWarm = rdb.prepare(updateSql)
+
+    proc benchUpdatePreparedWarm(): Future[seq[JsonNode]] {.async.} =
+      var response = newSeq[JsonNode](countNum)
+      var futures = newSeq[Future[void]](countNum)
+      for i in 1..countNum:
+        let index = rand(range1_10000)
+        let number = rand(range1_10000)
+        futures[i - 1] = (proc(): Future[void] {.async.} =
+          when declared(PostgresPreparedContext) and compiles(
+            rdb.withConn(
+              proc(ctx: PostgresPreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
+          ):
+            await rdb.withConn(
+              proc(ctx: PostgresPreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
+          else:
+            discard await selectStmtWarm.first(@[$index])
+            await updateStmtWarm.exec(@[$number, $index])
+        )()
+        response[i - 1] = %*{"id": index, "randomNumber": number}
+      await all(futures)
+      return response
 
   proc timeProcess[T](name: system.string, cb: proc(): Future[T]) {.async.} =
     var eachTime = 0.0
@@ -129,7 +160,10 @@ template benchmarkScenario(rdb: untyped, useBackticks: static[bool]): untyped =
   migrate().waitFor
   waitFor timeProcess("update", benchUpdate)
   when compiles(rdb.prepare("SELECT 1")):
-    waitFor timeProcess("update prepared", benchUpdatePrepared)
+    waitFor timeProcess("update prepared cold", benchUpdatePreparedCold)
+    waitFor timeProcess("update prepared warm", benchUpdatePreparedWarm)
+    waitFor selectStmtWarm.close()
+    waitFor updateStmtWarm.close()
 
 
 when isExistsSqlite:

--- a/src/allographer/query_builder/models/mariadb/mariadb_exec.nim
+++ b/src/allographer/query_builder/models/mariadb/mariadb_exec.nim
@@ -7,6 +7,7 @@ import std/strutils
 import std/sequtils
 import std/tables
 import std/times
+import ../../error
 import ../../libs/mariadb/mariadb_impl
 import ../../libs/mariadb/mariadb_rdb except Option, cuint
 import ../../log
@@ -56,6 +57,10 @@ proc returnConn(self:MariadbConnections | MariadbQuery | RawMariadbQuery, i: int
   if i != errorConnectionNum:
     self.pools.conns[i].isBusy = false
     wakeOnePoolWaiter(self.pools)
+
+
+proc raisePoolTimeout(self: MariadbConnections | MariadbQuery | RawMariadbQuery | MariadbPreparedStatement) {.noreturn.} =
+  raise newException(DbError, "Timed out while waiting for a free MariaDB connection")
 
 
 proc prepare*(self: MariadbConnections, sql: string): MariadbPreparedStatement =
@@ -120,7 +125,7 @@ proc getAllRows(self:MariadbQuery, queryString:string):Future[seq[JsonNode]] {.a
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mariadb_impl.query(
     self.pools.conns[connI].conn,
@@ -143,7 +148,7 @@ proc getAllRowsPlain(self:MariadbQuery, queryString:string, args:JsonNode):Futur
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = mariadb_impl.query(
     self.pools.conns[connI].conn,
@@ -163,7 +168,7 @@ proc getRow(self:MariadbQuery, queryString:string):Future[Option[JsonNode]] {.as
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mariadb_impl.query(
     self.pools.conns[connI].conn,
@@ -186,7 +191,7 @@ proc getRowPlain(self:MariadbQuery, queryString:string, args:JsonNode):Future[se
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   
   let (rows, _) = mariadb_impl.query(
     self.pools.conns[connI].conn,
@@ -218,7 +223,7 @@ proc exec(self:MariadbQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let columns = self.getCachedColumnTypes(connI).await
   mariadb_impl.exec(self.pools.conns[connI].conn, queryString, self.placeHolder, columns, self.pools.timeout).await
@@ -232,7 +237,7 @@ proc insertId(self:MariadbQuery, queryString:string, key:string):Future[string] 
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let columns = self.getCachedColumnTypes(connI).await
   let (rows, _) = mariadb_impl.execGetValue(self.pools.conns[connI].conn, queryString, self.placeHolder, columns, self.pools.timeout).await
@@ -247,7 +252,7 @@ proc getAllRows(self:RawMariadbQuery, queryString:string):Future[seq[JsonNode]] 
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mariadb_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -271,7 +276,7 @@ proc getAllRowsPlain(self:RawMariadbQuery, queryString:string, args:JsonNode):Fu
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = mariadb_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -291,7 +296,7 @@ proc getRow(self:RawMariadbQuery, queryString:string):Future[Option[JsonNode]] {
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mariadb_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -314,7 +319,7 @@ proc getRowPlain(self:RawMariadbQuery, queryString:string, args:JsonNode):Future
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = mariadb_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -333,7 +338,7 @@ proc exec(self:RawMariadbQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   mariadb_impl.exec(
     self.pools.conns[connI].conn,
@@ -351,7 +356,7 @@ proc getColumns(self:MariadbQuery, queryString:string):Future[seq[string]] {.asy
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -378,7 +383,7 @@ proc getColumns(self:MariadbQuery, queryString:string):Future[seq[string]] {.asy
 proc transactionStart(self:MariadbConnections) {.async.} =
   let connI = getFreeConn(self).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   self.isInTransaction = true
   self.transactionConn = connI
 
@@ -402,7 +407,7 @@ proc getPreparedRows(self: MariadbPreparedStatement, args: seq[PreparedParam]): 
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let stmt = await self.ensurePreparedStmt(connI)
   if connI >= self.resultBindCache.len:
@@ -455,7 +460,7 @@ proc execPrepared(self: MariadbPreparedStatement, args: seq[PreparedParam]) {.as
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let stmt = await self.ensurePreparedStmt(connI)
   await mariadb_impl.execPreparedStmt(

--- a/src/allographer/query_builder/models/mysql/mysql_exec.nim
+++ b/src/allographer/query_builder/models/mysql/mysql_exec.nim
@@ -5,6 +5,7 @@ import std/strformat
 import std/strutils
 import std/sequtils
 import std/times
+import ../../error
 import ../../libs/mysql/mysql_impl
 import ../../libs/mysql/mysql_rdb except Option
 import ../../log
@@ -35,6 +36,10 @@ proc getFreeConn(self:MysqlConnections | MysqlQuery | RawMysqlQuery):Future[int]
 proc returnConn(self:MysqlConnections | MysqlQuery | RawMysqlQuery, i: int) {.async.} =
   if i != errorConnectionNum:
     self.pools.conns[i].isBusy = false
+
+
+proc raisePoolTimeout(self: MysqlConnections | MysqlQuery | RawMysqlQuery | MysqlPreparedStatement) {.noreturn.} =
+  raise newException(DbError, "Timed out while waiting for a free MySQL connection")
 
 
 # ================================================================================
@@ -83,7 +88,7 @@ proc getAllRows(self:MysqlQuery, queryString:string):Future[seq[JsonNode]] {.asy
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mysql_impl.query(
     self.pools.conns[connI].conn,
@@ -106,7 +111,7 @@ proc getAllRowsPlain(self:MysqlQuery, queryString:string, args:JsonNode):Future[
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = mysql_impl.query(
     self.pools.conns[connI].conn,
@@ -126,7 +131,7 @@ proc getRow(self:MysqlQuery, queryString:string):Future[Option[JsonNode]] {.asyn
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mysql_impl.query(
     self.pools.conns[connI].conn,
@@ -149,7 +154,7 @@ proc getRowPlain(self:MysqlQuery, queryString:string, args:JsonNode):Future[seq[
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   
   let (rows, _) = mysql_impl.query(
     self.pools.conns[connI].conn,
@@ -168,7 +173,7 @@ proc exec(self:MysqlQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let database = self.info.database
   let table = self.query["table"].getStr
@@ -184,7 +189,7 @@ proc insertId(self:MysqlQuery, queryString:string, key:string):Future[string] {.
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let table = self.query["table"].getStr
   let columnGetQuery = &"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table}'"
@@ -205,7 +210,7 @@ proc getAllRows(self:RawMysqlQuery, queryString:string):Future[seq[JsonNode]] {.
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mysql_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -229,7 +234,7 @@ proc getAllRowsPlain(self:RawMysqlQuery, queryString:string, args:JsonNode):Futu
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = mysql_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -249,7 +254,7 @@ proc getRow(self:RawMysqlQuery, queryString:string):Future[Option[JsonNode]] {.a
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = mysql_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -272,7 +277,7 @@ proc getRowPlain(self:RawMysqlQuery, queryString:string, args:JsonNode):Future[s
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = mysql_impl.rawQuery(
     self.pools.conns[connI].conn,
@@ -291,7 +296,7 @@ proc exec(self:RawMysqlQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   mysql_impl.exec(
     self.pools.conns[connI].conn,
@@ -309,7 +314,7 @@ proc getColumns(self:MysqlQuery, queryString:string):Future[seq[string]] {.async
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -336,7 +341,7 @@ proc getColumns(self:MysqlQuery, queryString:string):Future[seq[string]] {.async
 proc transactionStart(self:MysqlConnections) {.async.} =
   let connI = getFreeConn(self).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   self.isInTransaction = true
   self.transactionConn = connI
 
@@ -632,7 +637,7 @@ proc getPreparedRows(self: MysqlPreparedStatement, args: seq[PreparedParam]): Fu
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let stmt = await self.ensurePreparedStmt(connI)
   if connI >= self.resultBindCache.len:
@@ -685,7 +690,7 @@ proc execPrepared(self: MysqlPreparedStatement, args: seq[PreparedParam]) {.asyn
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let stmt = await self.ensurePreparedStmt(connI)
   await mysql_impl.execPreparedStmt(

--- a/src/allographer/query_builder/models/postgres/postgres_exec.nim
+++ b/src/allographer/query_builder/models/postgres/postgres_exec.nim
@@ -9,6 +9,7 @@ import std/strutils
 import std/sequtils
 import std/tables
 import std/times
+import ../../error
 import ../../libs/postgres/postgres_lib
 import ../../libs/postgres/postgres_impl
 import ../../log
@@ -78,18 +79,50 @@ proc returnConn(self: PostgresConnections | PostgresQuery | RawPostgresQuery, i:
     wakeOnePoolWaiter(self.pools)
 
 
+proc raisePoolTimeout(self: PostgresConnections | PostgresQuery | RawPostgresQuery | PostgresPreparedStatement) {.noreturn.} =
+  raise newException(DbError, "Timed out while waiting for a free PostgreSQL connection")
+
+
+proc touchStmtEntry(entry: PostgresPreparedEntry) =
+  entry.lastUsedAt = getTime().toUnix()
+
+
+proc mustBeOpen(self: PostgresPreparedStatement) =
+  if self.isNil or self.isClosed:
+    raise newException(DbError, "PostgreSQL prepared statement is already closed")
+
+
+proc getStmtEntry(self: PostgresConnections, sql: string): PostgresPreparedEntry =
+  if self.pools.preparedCache.hasKey(sql):
+    return self.pools.preparedCache[sql]
+  let entry = PostgresPreparedEntry(
+    sql: sql,
+    nArgs: countQuestionMarks(sql),
+    stmtBaseName: &"allographer_stmt_{gPreparedStmtCounter.fetchAdd(1)}",
+    stmtNames: newSeq[string](self.pools.conns.len),
+    refCount: 0,
+    lastUsedAt: getTime().toUnix(),
+  )
+  self.pools.preparedCache[sql] = entry
+  return entry
+
+
 proc prepare*(self: PostgresConnections, sql: string): PostgresPreparedStatement =
+  let entry = self.getStmtEntry(sql)
+  entry.refCount += 1
+  touchStmtEntry(entry)
   new(result)
   result.owner = self
+  result.entry = entry
   result.sql = sql
-  result.stmtBaseName = &"allographer_stmt_{gPreparedStmtCounter.fetchAdd(1)}"
-  result.stmtNames = newSeq[string](self.pools.conns.len)
-  result.nArgs = countQuestionMarks(sql)
+  result.nArgs = entry.nArgs
+  result.isClosed = false
 
 
-proc ensurePreparedStmt(self: PostgresPreparedStatement, connI: int): Future[string] {.async.} =
-  if self.stmtNames[connI].len == 0:
-    let stmtName = &"{self.stmtBaseName}_{connI}"
+proc ensureStmt(self: PostgresPreparedStatement, connI: int): Future[string] {.async.} =
+  self.mustBeOpen()
+  if self.entry.stmtNames[connI].len == 0:
+    let stmtName = &"{self.entry.stmtBaseName}_{connI}"
     await postgres_impl.prepare(
       self.owner.pools.conns[connI].conn,
       self.sql,
@@ -97,8 +130,9 @@ proc ensurePreparedStmt(self: PostgresPreparedStatement, connI: int): Future[str
       stmtName,
       self.nArgs
     )
-    self.stmtNames[connI] = stmtName
-  return self.stmtNames[connI]
+    self.entry.stmtNames[connI] = stmtName
+  touchStmtEntry(self.entry)
+  return self.entry.stmtNames[connI]
 
 
 # ================================================================================
@@ -167,7 +201,7 @@ proc getAllRows(self:PostgresQuery, queryString:string):Future[seq[JsonNode]] {.
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = postgres_impl.query(
     self.pools.conns[connI].conn,
@@ -190,7 +224,7 @@ proc getAllRowsPlain(self:PostgresQuery, queryString:string, args:JsonNode):Futu
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, _) = postgres_impl.query(
     self.pools.conns[connI].conn,
@@ -211,7 +245,7 @@ proc getRow(self:PostgresQuery, queryString:string, connI:int=0):Future[Option[J
       self.returnConn(connI).await
 
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let (rows, dbRows) = postgres_impl.query(
     self.pools.conns[connI].conn,
@@ -234,7 +268,7 @@ proc getRowPlain(self:PostgresQuery, queryString:string, args:JsonNode):Future[s
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   
   let (rows, _) = postgres_impl.query(
     self.pools.conns[connI].conn,
@@ -254,7 +288,7 @@ proc exec(self:PostgresQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let columns = getCachedColumnTypes(self, connI).await
   postgres_impl.exec(self.pools.conns[connI].conn, queryString, self.placeHolder, columns, self.pools.timeout).await
@@ -268,7 +302,7 @@ proc insertId(self:PostgresQuery, queryString:string, key:string):Future[string]
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let columns = getCachedColumnTypes(self, connI).await
   let (rows, _) = postgres_impl.execGetValue(self.pools.conns[connI].conn, queryString, self.placeHolder, columns, self.pools.timeout).await
@@ -283,7 +317,7 @@ proc getAllRows(self:RawPostgresQuery, queryString:string):Future[seq[JsonNode]]
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let queryString = queryString.questionToDaller()
 
@@ -308,7 +342,7 @@ proc getAllRowsPlain(self:RawPostgresQuery, queryString:string, args:JsonNode):F
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let queryString = queryString.questionToDaller()
 
@@ -330,7 +364,7 @@ proc getRow(self:RawPostgresQuery, queryString:string):Future[Option[JsonNode]] 
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let queryString = queryString.questionToDaller()
 
@@ -355,7 +389,7 @@ proc getRowPlain(self:RawPostgresQuery, queryString:string, args:JsonNode):Futur
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let queryString = queryString.questionToDaller()
   
@@ -377,7 +411,7 @@ proc exec(self:RawPostgresQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let queryString = queryString.questionToDaller()
 
@@ -397,7 +431,7 @@ proc getColumn(self:PostgresQuery, queryString:string):Future[seq[string]] {.asy
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -424,7 +458,7 @@ proc getColumn(self:PostgresQuery, queryString:string):Future[seq[string]] {.asy
 proc transactionStart(self:PostgresConnections|PostgresQuery) {.async.} =
   let connI = getFreeConn(self).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   self.isInTransaction = true
   self.transactionConn = connI
 
@@ -438,17 +472,44 @@ proc transactionEnd(self:PostgresConnections|PostgresQuery, query:string) {.asyn
   self.isInTransaction = false
 
 
-proc getPreparedRows(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
-  var connI = self.owner.transactionConn
-  if not self.owner.isInTransaction:
-    connI = getFreeConn(self.owner).await
-  defer:
-    if not self.owner.isInTransaction:
-      self.owner.returnConn(connI).await
-  if connI == errorConnectionNum:
+proc withConn*(
+  self: PostgresConnections,
+  body: proc (ctx: PostgresPreparedContext): Future[void]
+) {.async.} =
+  if self.isInTransaction:
+    let ctx = PostgresPreparedContext(owner: self, connI: self.transactionConn)
+    await body(ctx)
     return
 
-  let stmtName = await self.ensurePreparedStmt(connI)
+  let connI = getFreeConn(self).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  defer:
+    self.returnConn(connI).await
+
+  let ctx = PostgresPreparedContext(owner: self, connI: connI)
+  await body(ctx)
+
+
+proc verifyCtx(self: PostgresPreparedStatement, ctx: PostgresPreparedContext) =
+  self.mustBeOpen()
+  if ctx.isNil:
+    raise newException(DbError, "PostgreSQL prepared context is nil")
+  if ctx.owner != self.owner:
+    raise newException(DbError, "PostgreSQL prepared context owner mismatch")
+  if ctx.connI < 0 or ctx.connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "PostgreSQL prepared context has invalid connection index")
+
+
+proc getRowsOnConn(
+  self: PostgresPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "PostgreSQL prepared statement received an invalid connection index")
+  let stmtName = await self.ensureStmt(connI)
   return postgres_impl.preparedQuery(
     self.owner.pools.conns[connI].conn,
     args,
@@ -458,36 +519,7 @@ proc getPreparedRows(self: PostgresPreparedStatement, args: seq[PreparedParam]):
   ).await
 
 
-proc getPreparedAllRows(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
-  let (rows, dbRows) = await self.getPreparedRows(args)
-  if rows.len == 0:
-    self.owner.log.echoErrorMsg(self.sql)
-    return newSeq[JsonNode](0)
-  return toJson(rows, dbRows)
-
-
-proc getPreparedRow(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[Option[JsonNode]] {.async.} =
-  let (rows, dbRows) = await self.getPreparedRows(args)
-  if rows.len == 0:
-    self.owner.log.echoErrorMsg(self.sql)
-    return none(JsonNode)
-  return toJson(rows, dbRows)[0].some()
-
-
-proc getPreparedAllRowsPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[seq[string]]] {.async.} =
-  let (rows, _) = await self.getPreparedRows(args)
-  return rows
-
-
-proc getPreparedRowPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[string]] {.async.} =
-  let (rows, _) = await self.getPreparedRows(args)
-  if rows.len == 0:
-    self.owner.log.echoErrorMsg(self.sql)
-    return newSeq[string](0)
-  return rows[0]
-
-
-proc execPrepared(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.async.} =
+proc getRows(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
   var connI = self.owner.transactionConn
   if not self.owner.isInTransaction:
     connI = getFreeConn(self.owner).await
@@ -495,9 +527,122 @@ proc execPrepared(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.a
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
+  return await self.getRowsOnConn(connI, args)
 
-  let stmtName = await self.ensurePreparedStmt(connI)
+
+proc getRows(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.verifyCtx(ctx)
+  return await self.getRowsOnConn(ctx.connI, args)
+
+
+proc getAll(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getRows(args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[JsonNode](0)
+  return toJson(rows, dbRows)
+
+
+proc getAll(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[JsonNode](0)
+  return toJson(rows, dbRows)
+
+
+proc getOne(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[Option[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getRows(args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return none(JsonNode)
+  return toJson(rows, dbRows)[0].some()
+
+
+proc getOne(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return none(JsonNode)
+  return toJson(rows, dbRows)[0].some()
+
+
+proc getAllPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[seq[string]]] {.async.} =
+  let (rows, _) = await self.getRows(args)
+  return rows
+
+
+proc getAllPlain(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  let (rows, _) = await self.getRows(ctx, args)
+  return rows
+
+
+proc getPlainRow(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[string]] {.async.} =
+  let (rows, _) = await self.getRows(args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[string](0)
+  return rows[0]
+
+
+proc getPlainRow(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  let (rows, _) = await self.getRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[string](0)
+  return rows[0]
+
+
+proc runExecOnConn(
+  self: PostgresPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+) {.async.}
+
+
+proc runExec(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.async.} =
+  var connI = self.owner.transactionConn
+  if not self.owner.isInTransaction:
+    connI = getFreeConn(self.owner).await
+  defer:
+    if not self.owner.isInTransaction:
+      self.owner.returnConn(connI).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  await self.runExecOnConn(connI, args)
+
+
+proc runExecOnConn(
+  self: PostgresPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "PostgreSQL prepared statement received an invalid connection index")
+
+  let stmtName = await self.ensureStmt(connI)
   await postgres_impl.preparedExec(
     self.owner.pools.conns[connI].conn,
     args,
@@ -507,50 +652,129 @@ proc execPrepared(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.a
   )
 
 
-proc preparedGet(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
+proc runExec(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.verifyCtx(ctx)
+  await self.runExecOnConn(ctx.connI, args)
+
+
+proc get(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
   try:
     self.owner.log.logger(self.sql)
-    return await self.getPreparedAllRows(args)
+    return await self.getAll(args)
   except CatchableError:
     self.owner.log.echoErrorMsg(self.sql)
     self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
     raise getCurrentException()
 
 
-proc preparedFirst(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[Option[JsonNode]] {.async.} =
+proc get(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
   try:
     self.owner.log.logger(self.sql)
-    return await self.getPreparedRow(args)
+    return await self.getAll(ctx, args)
   except CatchableError:
     self.owner.log.echoErrorMsg(self.sql)
     self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
     raise getCurrentException()
 
 
-proc preparedGetPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[seq[string]]] {.async.} =
+proc first(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[Option[JsonNode]] {.async.} =
   try:
     self.owner.log.logger(self.sql)
-    return await self.getPreparedAllRowsPlain(args)
+    return await self.getOne(args)
   except CatchableError:
     self.owner.log.echoErrorMsg(self.sql)
     self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
     raise getCurrentException()
 
 
-proc preparedFirstPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[string]] {.async.} =
+proc first(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
   try:
     self.owner.log.logger(self.sql)
-    return await self.getPreparedRowPlain(args)
+    return await self.getOne(ctx, args)
   except CatchableError:
     self.owner.log.echoErrorMsg(self.sql)
     self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
     raise getCurrentException()
 
 
-proc preparedExec(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.async.} =
+proc getPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[seq[string]]] {.async.} =
   try:
     self.owner.log.logger(self.sql)
-    await self.execPrepared(args)
+    return await self.getAllPlain(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc getPlain(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getAllPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc firstPlain(self: PostgresPreparedStatement, args: seq[PreparedParam]): Future[seq[string]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPlainRow(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc firstPlain(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPlainRow(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc exec(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.runExec(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc exec(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.runExec(ctx, args)
   except CatchableError:
     self.owner.log.echoErrorMsg(self.sql)
     self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
@@ -558,43 +782,123 @@ proc preparedExec(self: PostgresPreparedStatement, args: seq[PreparedParam]) {.a
 
 
 proc get*(self: PostgresPreparedStatement, args: seq[string]): Future[seq[JsonNode]] {.async.} =
-  return await self.preparedGet(args.toPreparedParams)
+  return await self.get(args.toPreparedParams)
+
+
+proc get*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[string]
+): Future[seq[JsonNode]] {.async.} =
+  return await self.get(ctx, args.toPreparedParams)
 
 
 proc get*(self: PostgresPreparedStatement, args: JsonNode): Future[seq[JsonNode]] {.async.} =
-  return await self.preparedGet(args.toPreparedParams)
+  return await self.get(args.toPreparedParams)
+
+
+proc get*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: JsonNode
+): Future[seq[JsonNode]] {.async.} =
+  return await self.get(ctx, args.toPreparedParams)
 
 
 proc first*(self: PostgresPreparedStatement, args: seq[string]): Future[Option[JsonNode]] {.async.} =
-  return await self.preparedFirst(args.toPreparedParams)
+  return await self.first(args.toPreparedParams)
+
+
+proc first*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[string]
+): Future[Option[JsonNode]] {.async.} =
+  return await self.first(ctx, args.toPreparedParams)
 
 
 proc first*(self: PostgresPreparedStatement, args: JsonNode): Future[Option[JsonNode]] {.async.} =
-  return await self.preparedFirst(args.toPreparedParams)
+  return await self.first(args.toPreparedParams)
+
+
+proc first*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: JsonNode
+): Future[Option[JsonNode]] {.async.} =
+  return await self.first(ctx, args.toPreparedParams)
 
 
 proc getPlain*(self: PostgresPreparedStatement, args: seq[string]): Future[seq[seq[string]]] {.async.} =
-  return await self.preparedGetPlain(args.toPreparedParams)
+  return await self.getPlain(args.toPreparedParams)
+
+
+proc getPlain*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[string]
+): Future[seq[seq[string]]] {.async.} =
+  return await self.getPlain(ctx, args.toPreparedParams)
 
 
 proc getPlain*(self: PostgresPreparedStatement, args: JsonNode): Future[seq[seq[string]]] {.async.} =
-  return await self.preparedGetPlain(args.toPreparedParams)
+  return await self.getPlain(args.toPreparedParams)
+
+
+proc getPlain*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: JsonNode
+): Future[seq[seq[string]]] {.async.} =
+  return await self.getPlain(ctx, args.toPreparedParams)
 
 
 proc firstPlain*(self: PostgresPreparedStatement, args: seq[string]): Future[seq[string]] {.async.} =
-  return await self.preparedFirstPlain(args.toPreparedParams)
+  return await self.firstPlain(args.toPreparedParams)
+
+
+proc firstPlain*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[string]
+): Future[seq[string]] {.async.} =
+  return await self.firstPlain(ctx, args.toPreparedParams)
 
 
 proc firstPlain*(self: PostgresPreparedStatement, args: JsonNode): Future[seq[string]] {.async.} =
-  return await self.preparedFirstPlain(args.toPreparedParams)
+  return await self.firstPlain(args.toPreparedParams)
+
+
+proc firstPlain*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: JsonNode
+): Future[seq[string]] {.async.} =
+  return await self.firstPlain(ctx, args.toPreparedParams)
 
 
 proc exec*(self: PostgresPreparedStatement, args: seq[string]) {.async.} =
-  await self.preparedExec(args.toPreparedParams)
+  await self.exec(args.toPreparedParams)
+
+
+proc exec*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: seq[string]
+) {.async.} =
+  await self.exec(ctx, args.toPreparedParams)
 
 
 proc exec*(self: PostgresPreparedStatement, args: JsonNode) {.async.} =
-  await self.preparedExec(args.toPreparedParams)
+  await self.exec(args.toPreparedParams)
+
+
+proc exec*(
+  self: PostgresPreparedStatement,
+  ctx: PostgresPreparedContext,
+  args: JsonNode
+) {.async.} =
+  await self.exec(ctx, args.toPreparedParams)
 
 
 # ================================================================================
@@ -911,23 +1215,45 @@ proc firstPlain*(self: RawPostgresQuery):Future[seq[string]] {.async.} =
   return self.getRowPlain(self.queryString, self.placeHolder).await
 
 
-proc deallocatePreparedStmtSafely(self: PostgresPreparedStatement, connI: int, stmtName: string): Future[void] {.async.} =
+proc deallocStmtSafely(
+  self: PostgresConnections,
+  connI: int,
+  stmtName: string
+): Future[void] {.async.} =
   try:
-    await postgres_impl.deallocate(self.owner.pools.conns[connI].conn, stmtName, self.owner.pools.timeout)
+    await postgres_impl.deallocate(self.pools.conns[connI].conn, stmtName, self.pools.timeout)
   except CatchableError:
-    self.owner.log.echoErrorMsg("deallocate failed for " & stmtName & ": " & getCurrentExceptionMsg())
+    self.log.echoErrorMsg("deallocate failed for " & stmtName & ": " & getCurrentExceptionMsg())
 
 
 proc close*(self: PostgresPreparedStatement) {.async.} =
+  if self.isNil or self.isClosed:
+    return
+  self.isClosed = true
+  if not self.entry.isNil:
+    if self.entry.refCount > 0:
+      self.entry.refCount -= 1
+    touchStmtEntry(self.entry)
+
+
+proc flushStmt*(self: PostgresConnections, sql: string) {.async.} =
+  if not self.pools.preparedCache.hasKey(sql):
+    return
+  let entry = self.pools.preparedCache[sql]
   var futs: seq[Future[void]]
-  for i, stmtName in self.stmtNames:
+  for i, stmtName in entry.stmtNames:
     if stmtName.len == 0:
       continue
-    futs.add(self.deallocatePreparedStmtSafely(i, stmtName))
+    futs.add(self.deallocStmtSafely(i, stmtName))
   if futs.len > 0:
     await all(futs)
-  for i in 0 ..< self.stmtNames.len:
-    self.stmtNames[i] = ""
+  self.pools.preparedCache.del(sql)
+
+
+proc clearStmtCache*(self: PostgresConnections) {.async.} =
+  let keys = toSeq(self.pools.preparedCache.keys)
+  for sql in keys:
+    await self.flushStmt(sql)
 
 
 template seeder*(rdb:PostgresConnections, tableName:string, body:untyped):untyped =

--- a/src/allographer/query_builder/models/postgres/postgres_open.nim
+++ b/src/allographer/query_builder/models/postgres/postgres_open.nim
@@ -31,6 +31,7 @@ proc dbOpen*(_:type PostgreSQL, database: string, user: string, password: string
     timeout: timeout,
     waiters: initDeque[Future[void]](),
     columnTypeCache: initTable[string, seq[Row]](),
+    preparedCache: initTable[string, PostgresPreparedEntry](),
   )
   result = PostgresConnections(
     pools: pools,

--- a/src/allographer/query_builder/models/postgres/postgres_types.nim
+++ b/src/allographer/query_builder/models/postgres/postgres_types.nim
@@ -16,6 +16,15 @@ type Connection* = ref object
   createdAt*: int64
 
 
+type PostgresPreparedEntry* = ref object
+  sql*: string
+  nArgs*: int
+  stmtBaseName*: string
+  stmtNames*: seq[string]
+  refCount*: int
+  lastUsedAt*: int64
+
+
 type Connections* = ref object
   conns*: seq[Connection]
   timeout*: int
@@ -23,6 +32,8 @@ type Connections* = ref object
   waiters*: Deque[Future[void]]
   ## `exec` / `insertId` 用。テーブルごとに information_schema 相当の列型を初回のみ取得して保持する。
   columnTypeCache*: Table[string, seq[Row]]
+  ## SQL 単位の prepared statement cache。物理 prepare 状態は conn ごとに保持する。
+  preparedCache*: Table[string, PostgresPreparedEntry]
 
 
 ## created by `let rdb = dbOpen(PostgreSQL, "localhost", 5432)`
@@ -57,12 +68,17 @@ type RawPostgresQuery* = ref object
   transactionConn*: int
 
 
+type PostgresPreparedContext* = ref object
+  owner*: PostgresConnections
+  connI*: int
+
+
 type PostgresPreparedStatement* = ref object
   owner*: PostgresConnections
+  entry*: PostgresPreparedEntry
   sql*: string
-  stmtBaseName*: string
-  stmtNames*: seq[string]
   nArgs*: int
+  isClosed*: bool
 
 
 proc `$`*(self:PostgresConnections|PostgresQuery|RawPostgresQuery):string =

--- a/src/allographer/query_builder/models/sqlite/sqlite_exec.nim
+++ b/src/allographer/query_builder/models/sqlite/sqlite_exec.nim
@@ -7,6 +7,7 @@ import std/strutils
 import std/sequtils
 import std/tables
 import std/times
+import ../../error
 import ../../libs/sqlite/sqlite_impl
 import ../../libs/sqlite/sqlite_lib
 import ../../libs/sqlite/sqlite_rdb
@@ -73,6 +74,10 @@ proc returnConn(self: SqliteConnections | SqliteQuery | RawSqliteQuery, i: int) 
   if i != errorConnectionNum:
     self.pools.conns[i].isBusy = false
     wakeOnePoolWaiter(self.pools)
+
+
+proc raisePoolTimeout(self: SqliteConnections | SqliteQuery | RawSqliteQuery | SqlitePreparedStatement) {.noreturn.} =
+  raise newException(DbError, "Timed out while waiting for a free SQLite connection")
 
 
 proc prepare*(self: SqliteConnections, sql: string): SqlitePreparedStatement =
@@ -142,7 +147,7 @@ proc getAllRows(self:SqliteQuery, queryString:string):Future[seq[JsonNode]] {.as
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -179,7 +184,7 @@ proc getAllRowsPlain(self:SqliteQuery, queryString:string, args:JsonNode):Future
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in args.items:
@@ -212,7 +217,7 @@ proc getRow(self:SqliteQuery, queryString:string):Future[Option[JsonNode]] {.asy
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -249,7 +254,7 @@ proc getRowPlain(self:SqliteQuery, queryString:string, args:JsonNode):Future[seq
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in args.items:
@@ -281,7 +286,7 @@ proc getAllRows(self:RawSqliteQuery, queryString:string):Future[seq[JsonNode]] {
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -318,7 +323,7 @@ proc getAllRowsPlain(self:RawSqliteQuery, queryString:string, args:JsonNode):Fut
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in args.items:
@@ -351,7 +356,7 @@ proc getRow(self:RawSqliteQuery, queryString:string):Future[Option[JsonNode]] {.
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in self.placeHolder.items:
@@ -388,7 +393,7 @@ proc getRowPlain(self:RawSqliteQuery, queryString:string, args:JsonNode):Future[
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in args.items:
@@ -422,7 +427,7 @@ proc exec(self:SqliteQuery, queryString:string) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let columns = getCachedSqliteColumnTypes(self, connI).await
   sqlite_impl.exec(self.pools.conns[connI].conn, queryString, self.placeHolder, columns, self.pools.timeout).await
@@ -436,7 +441,7 @@ proc exec(self:RawSqliteQuery, queryString:string, args:JsonNode) {.async.} =
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   sqlite_impl.exec(self.pools.conns[connI].conn, queryString, args, self.pools.timeout).await
 
@@ -449,7 +454,7 @@ proc insertId(self:SqliteQuery, queryString:string, key:string):Future[string]{.
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let columns = getCachedSqliteColumnTypes(self, connI).await
   sqlite_impl.exec(self.pools.conns[connI].conn, queryString, self.placeHolder, columns, self.pools.timeout).await
@@ -485,7 +490,7 @@ proc getColumns(self:SqliteQuery, queryString:string, args=newJArray()):Future[s
     if not self.isInTransaction:
       self.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   var strArgs:seq[string]
   for arg in args.items:
@@ -512,7 +517,7 @@ proc getColumns(self:SqliteQuery, queryString:string, args=newJArray()):Future[s
 proc transactionStart(self:SqliteConnections) {.async.} =
   let connI = getFreeConn(self).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
   self.isInTransaction = true
   self.transactionConn = connI
   sqlite_impl.exec(self.pools.conns[connI].conn, "BEGIN", newJArray(), self.pools.timeout).await
@@ -535,7 +540,7 @@ proc getPreparedRows(self: SqlitePreparedStatement, args: seq[PreparedParam]): F
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let stmt = await self.ensurePreparedStmt(connI)
   if not self.hasCachedColumns:
@@ -588,7 +593,7 @@ proc execPrepared(self: SqlitePreparedStatement, args: seq[PreparedParam]) {.asy
     if not self.owner.isInTransaction:
       self.owner.returnConn(connI).await
   if connI == errorConnectionNum:
-    return
+    raisePoolTimeout(self)
 
   let stmt = await self.ensurePreparedStmt(connI)
   await sqlite_impl.preparedExecReuse(

--- a/tests/mariadb/test_pool_wait.nim
+++ b/tests/mariadb/test_pool_wait.nim
@@ -21,3 +21,9 @@ suite "MariaDB pool waiter (notify)":
     let b = sel()
     waitFor all(a, b)
     check rdb.pools.waiters.len == 0
+
+  test "pool size 0: raw get raises DbError":
+    let mariaUrl = getEnv("MARIA_URL")
+    let rdb = dbOpen(MariaDB, mariaUrl, maxConnections = 0, timeout = 0)
+    expect(DbError):
+      discard waitFor rdb.raw("SELECT 1").get()

--- a/tests/postgres/test_pool_wait.nim
+++ b/tests/postgres/test_pool_wait.nim
@@ -17,3 +17,9 @@ suite "PostgreSQL pool waiter (notify)":
     let a = sel()
     let b = sel()
     waitFor all(a, b)
+
+  test "pool size 0: raw get raises DbError":
+    let pgUrl = getEnv("PG_URL")
+    let rdb = dbOpen(PostgreSQL, pgUrl, maxConnections = 0, timeout = 0)
+    expect(DbError):
+      discard waitFor rdb.raw("SELECT 1").get()

--- a/tests/postgres/test_prepared_statement.nim
+++ b/tests/postgres/test_prepared_statement.nim
@@ -78,6 +78,44 @@ suite($rdb & " prepared statement"):
     check stmt.firstPlain(args).waitFor[1] == "user1"
 
 
+  test("logical close and clear cache"):
+    let sql = """SELECT "id", "name", "email", "address" FROM "user" WHERE "id" = ?"""
+    let stmt = rdb.prepare(sql)
+    discard waitFor stmt.first(@["1"])
+    waitFor stmt.close()
+
+    let stmt2 = rdb.prepare(sql)
+    defer:
+      waitFor stmt2.close()
+
+    let rowOpt = stmt2.first(@["1"]).waitFor
+    check rowOpt.isSome
+
+    waitFor rdb.clearStmtCache()
+    let stmt3 = rdb.prepare(sql)
+    defer:
+      waitFor stmt3.close()
+    check stmt3.first(@["1"]).waitFor.isSome
+
+
+  test("with prepared connection context"):
+    let selectStmt = rdb.prepare("""SELECT "id", "name" FROM "user" WHERE "id" = ?""")
+    let updateStmt = rdb.prepare("""UPDATE "user" SET "address" = ? WHERE "id" = ?""")
+    defer:
+      waitFor selectStmt.close()
+      waitFor updateStmt.close()
+
+    waitFor rdb.withConn(
+      proc(ctx: PostgresPreparedContext): Future[void] {.async.} =
+        discard await selectStmt.first(ctx, @["1"])
+        await updateStmt.exec(ctx, @["ctx-address", "1"])
+    )
+
+    let rowOpt = rdb.table("user").find(1).waitFor
+    let row = options.get(rowOpt)
+    check row["address"].getStr == "ctx-address"
+
+
   test("update null"):
     let stmt = rdb.prepare("""UPDATE "user" SET "address" = ? WHERE "id" = ?""")
     defer:

--- a/tests/sqlite/test_pool_wait.nim
+++ b/tests/sqlite/test_pool_wait.nim
@@ -17,3 +17,9 @@ suite "SQLite pool waiter (notify)":
     let a = sel()
     let b = sel()
     waitFor all(a, b)
+
+  test "pool size 0: raw get raises DbError":
+    let sqliteHost = getEnv("SQLITE_HOST")
+    let rdb = dbOpen(SQLite3, sqliteHost, maxConnections = 0, timeout = 0)
+    expect(DbError):
+      discard waitFor rdb.raw("SELECT 1").get()


### PR DESCRIPTION
…greSQL.

Raise DbError on connection pool timeouts across drivers and introduce raisePoolTimeout helpers; add per-SQL prepared cache, logical close/flush/clear APIs and a prepared-connection context for PostgreSQL; update benchmark (cold/warm prepared paths), documentation, and tests to cover pool-timeout and prepared-statement scenarios.