### PR TITLE
336 update prepared statement

### DIFF
--- a/.cursor/rules/branch/336-update-prepared-statement.mdc
+++ b/.cursor/rules/branch/336-update-prepared-statement.mdc
@@ -9,6 +9,7 @@ alwaysApply: false
 - `333-prepared-statement` で PostgreSQL 向けに整理・実装された prepared statement 改善を、可能な限り同じ公開 API で MariaDB / MySQL に横展開する
 - driver 差分は内部実装に閉じ込め、利用者から見える API は PostgreSQL と揃える
 - すでに PostgreSQL 側で実装済みの内容はこのブランチで再実装せず、未着手の MariaDB / MySQL 側へタスクを移す
+- MariaDB / MySQL の横展開が終わったら、PostgreSQL と MariaDB の実装を参考に SQLite にも同様の prepared statement 改善を展開する方針を持つ
 
 ## 進捗
 
@@ -33,6 +34,13 @@ alwaysApply: false
 - [x] MySQL prepared statement に `ctx` 付き overload を追加する
 - [x] benchmark の warm 経路が MariaDB / MySQL でも同じ API で通るようにする
 - [x] MariaDB / MySQL の prepared statement テストを PostgreSQL 相当まで拡張する
+- [x] SQLite の prepared statement 実装差分を確認した
+- [x] SQLite に PostgreSQL / MariaDB 相当の prepared cache を追加する
+- [x] SQLite の `close()` を論理 close 化し、物理破棄 API を分離する
+- [x] SQLite に PostgreSQL / MariaDB と揃う接続固定 API を追加する
+- [x] SQLite prepared statement に `ctx` 付き overload を追加する
+- [x] benchmark の warm 経路が SQLite でも同じ API で通るようにする
+- [x] SQLite の prepared statement テストを PostgreSQL / MariaDB 相当まで拡張する
 - [ ] API 名の差分を吸収するため、必要なら PostgreSQL 側の命名も含めて最終形を再確認する
 
 ## 参考資料
@@ -52,6 +60,10 @@ alwaysApply: false
   - `src/allographer/query_builder/models/mysql/mysql_types.nim`
   - `src/allographer/query_builder/models/mysql/mysql_exec.nim`
   - `tests/mysql/test_prepared_statement.nim`
+- SQLite 実装
+  - `src/allographer/query_builder/models/sqlite/sqlite_types.nim`
+  - `src/allographer/query_builder/models/sqlite/sqlite_exec.nim`
+  - `tests/sqlite/test_prepared_statement.nim`
 - benchmark
   - `example/benchmark.nim`
 
@@ -93,6 +105,19 @@ MariaDB / MySQL の prepared statement 実装は、まだ PostgreSQL 以前の�
 - benchmark の warm 経路は PostgreSQL 以外ではフォールバック実行になっている
 - テストは基本的な select / update 程度で、logical close や cache 維持、接続固定 API は未検証
 
+### 3.5 SQLite 側の現状
+
+SQLite の prepared statement 実装も、考え方としては MariaDB / MySQL の旧来実装に近い。
+
+- prepared statement ハンドル自身が `stmts: seq[PStmt]` を持つ
+- `prepare()` は毎回新しいハンドルを返し、プール単位 cache は持っていない
+- `close()` は各 `PStmt` を `finalize()` する物理 close である
+- `withConn` や `SqlitePreparedContext` は存在しない
+- prepared statement の `ctx` 付き overload はない
+- benchmark の warm 経路では SQLite は接続固定経路を使わず、通常の prepared 呼び出しへフォールバックする
+
+SQLite は server-side prepare を持たないが、公開 API を PostgreSQL / MariaDB / MySQL と揃える価値は高いので、このブランチでは「同じ API で使えること」を主眼に設計を寄せる。
+
 ### 4. このブランチの実装方針
 
 公開 API は PostgreSQL に寄せる。命名は「短く、意味が通じる」方を正とし、すでに PostgreSQL で使われている短い名前へ揃える。
@@ -100,12 +125,14 @@ MariaDB / MySQL の prepared statement 実装は、まだ PostgreSQL 以前の�
 統一方針:
 
 - 接続固定 API は全 driver で `withConn`
-- prepared context 型は driver ごとに `MariadbPreparedContext` / `MysqlPreparedContext`
+- prepared context 型は driver ごとに `MariadbPreparedContext` / `MysqlPreparedContext` / `SqlitePreparedContext`
 - cache clear API は全 driver で `clearStmtCache`
 - 個別破棄 API は全 driver で `flushStmt`
 - prepared statement の `close()` は全 driver で logical close
 
 この形なら `example/benchmark.nim` の warm 経路を driver ごとに似た形へ揃えやすい。
+
+SQLite については driver 特性上、cache entry が保持する実体は `PStmt` になり、物理破棄は `finalize()` を使う。ただし利用者から見える API は PostgreSQL / MariaDB / MySQL と同じに保つ。
 
 ### 5. 実装後の確認
 
@@ -114,6 +141,9 @@ MariaDB / MySQL の prepared statement 実装は、まだ PostgreSQL 以前の�
 - `withConn` と `MariadbPreparedContext` / `MysqlPreparedContext` を追加し、benchmark の warm 経路を共通化した
 - prepared statement の `ctx` 付き overload を追加し、MariaDB / MySQL テストでも接続固定経路を検証するようにした
 - `example/benchmark.nim` は PostgreSQL / MariaDB / MySQL で同じ warm パターンを選べるようになった
+- SQLite も同じ `withConn` パターンで warm prepared 経路を通すようにした
+- 次の横展開先として SQLite を扱う方針を明文化した
+- SQLite では `PStmt` の lifecycle を `preparedCache` / `flushStmt` / `clearStmtCache` へ寄せつつ、公開 API は他 driver と共通化する方針とする
 
 ### 6. 実装順序
 
@@ -143,9 +173,21 @@ MariaDB / MySQL の prepared statement 実装は、まだ PostgreSQL 以前の�
 - 接続固定 API 経由の select / update
 - transaction 中の接続選択との整合
 
+#### Phase 5
+
+- SQLite の型定義に prepared cache entry と context 型を追加する
+- `Connections` に prepared cache を持たせる
+- `prepare()` を SQL 単位 cache lookup ベースへ変更する
+- `close()` を logical close に変え、`flushStmt` / `clearStmtCache` を追加する
+- SQLite に `withConn` を追加する
+- prepared statement の `ctx` overload を追加する
+- benchmark の warm 経路を SQLite でも同じ書き方へ寄せる
+- SQLite テストを logical close、cache clear、接続固定 API まで拡張する
+
 ### 7. 注意点
 
 - `SYW-ARCH-001` / `SYW-ARCH-002` に従い、driver 差分を公開 API に漏らしすぎない
 - 既存の MariaDB / MySQL prepared statement API を壊す場合は移行影響を記録する
+- SQLite は driver 特性上 server-side state を持たないため、「PostgreSQL と同じ内部実装」ではなく「同じ公開 API と同じ利用体験」を揃える
 - 現時点で PostgreSQL は `withConn` / `clearStmtCache` 命名で先行しており、この命名を正式採用する
 - 実装中に PostgreSQL 側の API 名を再調整したくなった場合は、この文書の設計方針も合わせて更新する

--- a/.cursor/rules/branch/336-update-prepared-statement.mdc
+++ b/.cursor/rules/branch/336-update-prepared-statement.mdc
@@ -17,11 +17,11 @@ alwaysApply: false
 - [x] 既存 prepared statement API の到達点を SQLite / PostgreSQL / MariaDB / MySQL で確認した
 - [x] 現在の SurrealDB 実装と `/sql` 利用箇所を確認した
 - [x] SurrealDB v3 公式ドキュメントで parameter / HTTP `/sql` / transaction の仕様を確認した
-- [x] SurrealDB prepared statement 実装方針の設計書を `documents/surrealdb/prepared_statement.md` として作成する方針を整理した
-- [ ] `models/surreal` に prepared statement 用の型と公開 API を追加する
-- [ ] `libs/surreal` に multi-statement 実行と response 解析の共通処理を追加する
-- [ ] SurrealDB prepared statement のテストを追加する
-- [ ] 必要に応じて `documents/surrealdb/query_builder.md` / README を更新する
+- [x] SurrealDB prepared statement の設計と利用例を `documents/surrealdb/prepared_statement.md` に整理した
+- [x] `models/surreal` に prepared statement 用の型と公開 API を追加した
+- [x] `libs/surreal` に multi-statement 実行向けの共通処理を追加した
+- [x] SurrealDB prepared statement のテストを追加した
+- [x] `documents/surrealdb/query_builder.md` / `documents/rdb/query_builder.md` を更新した
 
 ## 参考資料
 
@@ -181,30 +181,13 @@ HTTP `/sql` だけを見ると、prepared statement は connection 固定が必�
 
 もし将来 multi-statement business query を扱うなら、別 API として `prepareBatch` あるいは transaction helper を検討する。
 
-### 8. 実装順序
+### 8. 実装結果
 
-#### Phase 1
-
-- `surreal_types.nim` に prepared 関連型を追加する
-- `Connections` に `preparedCache` を追加する
-- `prepare()` / `close()` / `flushStmt()` / `clearStmtCache()` の骨格を追加する
-
-#### Phase 2
-
-- `surreal_lib.nim` の placeholder 変換を prepared statement でも使える形に整理する
-- `surreal_impl.nim` に multi-statement response 検証の共通処理を追加する
-- `get` / `first` / `exec` を実装する
-
-#### Phase 3
-
-- `withConn` / `SurrealPreparedContext` を追加する
-- `ctx` 付き overload を実装する
-- `tests/surrealdb/test_prepared_statement.nim` を追加する
-
-#### Phase 4
-
-- 必要なら `documents/surrealdb/query_builder.md` に prepared statement の使い方を追記する
-- `schema_builder` 側の逐次 `/sql` 実行を将来的に batch 化できるか別タスクで評価する
+- `surreal_types.nim` に prepared 関連型を追加し、`Connections` に `preparedCache` を持たせた
+- `surreal_lib.nim` に prepared SQL 生成の共通関数を追加した
+- `surreal_exec.nim` に `prepare` / `get` / `first` / `exec` / `close` / `flushStmt` / `clearStmtCache` / `withConn` を追加した
+- `tests/surrealdb/test_prepared_statement.nim` を追加した
+- `documents/surrealdb/prepared_statement.md` と既存ドキュメントを同期した
 
 ### 9. テスト方針
 

--- a/.cursor/rules/branch/336-update-prepared-statement.mdc
+++ b/.cursor/rules/branch/336-update-prepared-statement.mdc
@@ -1,0 +1,151 @@
+---
+description: 336-update-prepared-statementブランチでの開発時に読み込む
+alwaysApply: false
+---
+336-update-prepared-statement ブランチでの prepared statement 横展開
+===
+
+このブランチで実装することは以下の通りです。
+- `333-prepared-statement` で PostgreSQL 向けに整理・実装された prepared statement 改善を、可能な限り同じ公開 API で MariaDB / MySQL に横展開する
+- driver 差分は内部実装に閉じ込め、利用者から見える API は PostgreSQL と揃える
+- すでに PostgreSQL 側で実装済みの内容はこのブランチで再実装せず、未着手の MariaDB / MySQL 側へタスクを移す
+
+## 進捗
+
+- [x] `.cursor/rules/branch/333-prepared-statement.mdc` の設計意図を確認した
+- [x] 現在ブランチが `336-update-prepared-statement` であることを確認した
+- [x] PostgreSQL 側の実装到達点をコードベースから確認した
+- [x] MariaDB / MySQL 側の prepared statement 実装差分を確認した
+- [x] PostgreSQL 側で以下が実装済みであることを確認した
+- [x] PostgreSQL のプール単位 prepared cache
+- [x] PostgreSQL の論理 close と `clearStmtCache` / `flushStmt`
+- [x] PostgreSQL の接続固定 API `withConn` と `PostgresPreparedContext`
+- [x] PostgreSQL prepared statement の `ctx` 付き overload
+- [x] `example/benchmark.nim` の prepared cold / warm 計測
+- [x] PostgreSQL の基本テスト追加
+- [x] MariaDB に PostgreSQL 相当の prepared cache を追加する
+- [x] MySQL に PostgreSQL 相当の prepared cache を追加する
+- [x] MariaDB の `close()` を論理 close 化し、物理破棄 API を分離する
+- [x] MySQL の `close()` を論理 close 化し、物理破棄 API を分離する
+- [x] MariaDB に PostgreSQL と揃う接続固定 API を追加する
+- [x] MySQL に PostgreSQL と揃う接続固定 API を追加する
+- [x] MariaDB prepared statement に `ctx` 付き overload を追加する
+- [x] MySQL prepared statement に `ctx` 付き overload を追加する
+- [x] benchmark の warm 経路が MariaDB / MySQL でも同じ API で通るようにする
+- [x] MariaDB / MySQL の prepared statement テストを PostgreSQL 相当まで拡張する
+- [ ] API 名の差分を吸収するため、必要なら PostgreSQL 側の命名も含めて最終形を再確認する
+
+## 参考資料
+
+- 既存ブランチルール
+  - `.cursor/rules/branch/333-prepared-statement.mdc`
+- PostgreSQL 実装
+  - `src/allographer/query_builder/models/postgres/postgres_types.nim`
+  - `src/allographer/query_builder/models/postgres/postgres_exec.nim`
+  - `src/allographer/query_builder/models/postgres/postgres_open.nim`
+  - `tests/postgres/test_prepared_statement.nim`
+- MariaDB 実装
+  - `src/allographer/query_builder/models/mariadb/mariadb_types.nim`
+  - `src/allographer/query_builder/models/mariadb/mariadb_exec.nim`
+  - `tests/mariadb/test_prepared_statement.nim`
+- MySQL 実装
+  - `src/allographer/query_builder/models/mysql/mysql_types.nim`
+  - `src/allographer/query_builder/models/mysql/mysql_exec.nim`
+  - `tests/mysql/test_prepared_statement.nim`
+- benchmark
+  - `example/benchmark.nim`
+
+## 調査結果・設計まとめ
+
+### 1. PostgreSQL 側で実装済みの内容
+
+`333-prepared-statement` に書かれていた PostgreSQL 向け主要タスクは、コードベース上かなり進んでいる。
+
+- `Connections.preparedCache` が追加済み
+- `prepare()` は SQL 単位で cache entry を引く形になっている
+- `close()` は logical close になっており、entry の refCount を下げるだけになっている
+- 物理破棄 API として `flushStmt(sql)` / `clearStmtCache()` が入っている
+- 接続固定 API は設計書の `withPreparedConnection` ではなく `withConn` という名前で実装済み
+- `PostgresPreparedContext` と、`get/first/getPlain/firstPlain/exec` の `ctx` overload が実装済み
+- benchmark は prepared cold / warm に分かれており、PostgreSQL では `withConn` を使う分岐が入っている
+- PostgreSQL テストには logical close、cache clear、接続固定 API の確認が追加済み
+
+### 2. PostgreSQL 側で未完了または名称確定済みの点
+
+`333-prepared-statement` の設計と完全一致ではない点が残っている。
+
+- 接続固定 API 名は `withConn` を正とする
+- cache clear API 名は `clearStmtCache` を正とする
+- eviction / `preparedCacheMaxEntries` / LRU の Phase 3 は未実装
+- 「physical prepare が 1 回に収まること」を直接見るテストはまだ入っていない
+
+このブランチではまず MariaDB / MySQL への API 横展開を優先し、PostgreSQL の高度な eviction は別タスクとして扱う。
+
+### 3. MariaDB / MySQL 側の現状
+
+MariaDB / MySQL の prepared statement 実装は、まだ PostgreSQL 以前の形に近い。
+
+- prepared statement ハンドル自身が `stmts: seq[PSTMT]` を持つ
+- `prepare()` は毎回新しいハンドルを返し、プール単位 cache は持っていない
+- `close()` は各 `PSTMT` を物理 close する
+- 接続固定 API がない
+- prepared statement の `ctx` 付き overload がない
+- benchmark の warm 経路は PostgreSQL 以外ではフォールバック実行になっている
+- テストは基本的な select / update 程度で、logical close や cache 維持、接続固定 API は未検証
+
+### 4. このブランチの実装方針
+
+公開 API は PostgreSQL に寄せる。命名は「短く、意味が通じる」方を正とし、すでに PostgreSQL で使われている短い名前へ揃える。
+
+統一方針:
+
+- 接続固定 API は全 driver で `withConn`
+- prepared context 型は driver ごとに `MariadbPreparedContext` / `MysqlPreparedContext`
+- cache clear API は全 driver で `clearStmtCache`
+- 個別破棄 API は全 driver で `flushStmt`
+- prepared statement の `close()` は全 driver で logical close
+
+この形なら `example/benchmark.nim` の warm 経路を driver ごとに似た形へ揃えやすい。
+
+### 5. 実装後の確認
+
+- MariaDB / MySQL でも `Connections.preparedCache` を持ち、SQL ごとに `PSTMT` を再利用するようにした
+- `close()` は MariaDB / MySQL でも論理 close に変更し、物理破棄は `flushStmt` / `clearStmtCache` に分離した
+- `withConn` と `MariadbPreparedContext` / `MysqlPreparedContext` を追加し、benchmark の warm 経路を共通化した
+- prepared statement の `ctx` 付き overload を追加し、MariaDB / MySQL テストでも接続固定経路を検証するようにした
+- `example/benchmark.nim` は PostgreSQL / MariaDB / MySQL で同じ warm パターンを選べるようになった
+
+### 6. 実装順序
+
+#### Phase 1
+
+- MariaDB / MySQL の型定義に prepared cache entry と context 型を追加する
+- `Connections` に prepared cache を持たせる
+- `prepare()` を SQL 単位 cache lookup ベースへ変更する
+
+#### Phase 2
+
+- MariaDB / MySQL の `close()` を logical close に変える
+- `flushStmt` / `clearStmtCache` を追加する
+- 接続 close 時に物理 prepared state が自然破棄される前提との差分を確認する
+
+#### Phase 3
+
+- MariaDB / MySQL に `withConn` を追加する
+- prepared statement の `ctx` overload を追加する
+- benchmark の warm 経路を PostgreSQL と同じ書き方へ寄せる
+
+#### Phase 4
+
+- MariaDB / MySQL テストを拡張する
+- logical close 後の再利用
+- cache clear 後の再 prepare
+- 接続固定 API 経由の select / update
+- transaction 中の接続選択との整合
+
+### 7. 注意点
+
+- `SYW-ARCH-001` / `SYW-ARCH-002` に従い、driver 差分を公開 API に漏らしすぎない
+- 既存の MariaDB / MySQL prepared statement API を壊す場合は移行影響を記録する
+- 現時点で PostgreSQL は `withConn` / `clearStmtCache` 命名で先行しており、この命名を正式採用する
+- 実装中に PostgreSQL 側の API 名を再調整したくなった場合は、この文書の設計方針も合わせて更新する

--- a/.cursor/rules/branch/336-update-prepared-statement.mdc
+++ b/.cursor/rules/branch/336-update-prepared-statement.mdc
@@ -6,188 +6,218 @@ alwaysApply: false
 ===
 
 このブランチで実装することは以下の通りです。
-- `333-prepared-statement` で PostgreSQL 向けに整理・実装された prepared statement 改善を、可能な限り同じ公開 API で MariaDB / MySQL に横展開する
-- driver 差分は内部実装に閉じ込め、利用者から見える API は PostgreSQL と揃える
-- すでに PostgreSQL 側で実装済みの内容はこのブランチで再実装せず、未着手の MariaDB / MySQL 側へタスクを移す
-- MariaDB / MySQL の横展開が終わったら、PostgreSQL と MariaDB の実装を参考に SQLite にも同様の prepared statement 改善を展開する方針を持つ
+- 既存の SQLite / PostgreSQL / MySQL / MariaDB の prepared statement API を参照しつつ、SurrealDB 向け prepared statement API を追加する
+- SurrealDB v3 の `/sql` API と SurrealQL の `LET` / parameter 仕様を前提に、server-side prepare ではなく client-side template reuse と 1 リクエスト多文実行で prepared statement 的な使い勝手を実現する
+- SurrealDB 固有事情は `models/surreal` と `libs/surreal` に閉じ込め、公開 API は既存 driver と可能な限り揃える
+- このターンでは実装は行わず、調査結果と実装方針の設計書を固める
 
 ## 進捗
 
-- [x] `.cursor/rules/branch/333-prepared-statement.mdc` の設計意図を確認した
-- [x] 現在ブランチが `336-update-prepared-statement` であることを確認した
-- [x] PostgreSQL 側の実装到達点をコードベースから確認した
-- [x] MariaDB / MySQL 側の prepared statement 実装差分を確認した
-- [x] PostgreSQL 側で以下が実装済みであることを確認した
-- [x] PostgreSQL のプール単位 prepared cache
-- [x] PostgreSQL の論理 close と `clearStmtCache` / `flushStmt`
-- [x] PostgreSQL の接続固定 API `withConn` と `PostgresPreparedContext`
-- [x] PostgreSQL prepared statement の `ctx` 付き overload
-- [x] `example/benchmark.nim` の prepared cold / warm 計測
-- [x] PostgreSQL の基本テスト追加
-- [x] MariaDB に PostgreSQL 相当の prepared cache を追加する
-- [x] MySQL に PostgreSQL 相当の prepared cache を追加する
-- [x] MariaDB の `close()` を論理 close 化し、物理破棄 API を分離する
-- [x] MySQL の `close()` を論理 close 化し、物理破棄 API を分離する
-- [x] MariaDB に PostgreSQL と揃う接続固定 API を追加する
-- [x] MySQL に PostgreSQL と揃う接続固定 API を追加する
-- [x] MariaDB prepared statement に `ctx` 付き overload を追加する
-- [x] MySQL prepared statement に `ctx` 付き overload を追加する
-- [x] benchmark の warm 経路が MariaDB / MySQL でも同じ API で通るようにする
-- [x] MariaDB / MySQL の prepared statement テストを PostgreSQL 相当まで拡張する
-- [x] SQLite の prepared statement 実装差分を確認した
-- [x] SQLite に PostgreSQL / MariaDB 相当の prepared cache を追加する
-- [x] SQLite の `close()` を論理 close 化し、物理破棄 API を分離する
-- [x] SQLite に PostgreSQL / MariaDB と揃う接続固定 API を追加する
-- [x] SQLite prepared statement に `ctx` 付き overload を追加する
-- [x] benchmark の warm 経路が SQLite でも同じ API で通るようにする
-- [x] SQLite の prepared statement テストを PostgreSQL / MariaDB 相当まで拡張する
-- [ ] API 名の差分を吸収するため、必要なら PostgreSQL 側の命名も含めて最終形を再確認する
+- [x] `.cursor/rules/project.mdc` / `.cursor/rules/branch.mdc` / `.cursor/rules/branch/336-update-prepared-statement.mdc` を確認した
+- [x] 既存 prepared statement API の到達点を SQLite / PostgreSQL / MariaDB / MySQL で確認した
+- [x] 現在の SurrealDB 実装と `/sql` 利用箇所を確認した
+- [x] SurrealDB v3 公式ドキュメントで parameter / HTTP `/sql` / transaction の仕様を確認した
+- [x] SurrealDB prepared statement 実装方針の設計書を `documents/surrealdb/prepared_statement.md` として作成する方針を整理した
+- [ ] `models/surreal` に prepared statement 用の型と公開 API を追加する
+- [ ] `libs/surreal` に multi-statement 実行と response 解析の共通処理を追加する
+- [ ] SurrealDB prepared statement のテストを追加する
+- [ ] 必要に応じて `documents/surrealdb/query_builder.md` / README を更新する
 
 ## 参考資料
 
-- 既存ブランチルール
-  - `.cursor/rules/branch/333-prepared-statement.mdc`
-- PostgreSQL 実装
-  - `src/allographer/query_builder/models/postgres/postgres_types.nim`
-  - `src/allographer/query_builder/models/postgres/postgres_exec.nim`
-  - `src/allographer/query_builder/models/postgres/postgres_open.nim`
-  - `tests/postgres/test_prepared_statement.nim`
-- MariaDB 実装
-  - `src/allographer/query_builder/models/mariadb/mariadb_types.nim`
-  - `src/allographer/query_builder/models/mariadb/mariadb_exec.nim`
-  - `tests/mariadb/test_prepared_statement.nim`
-- MySQL 実装
-  - `src/allographer/query_builder/models/mysql/mysql_types.nim`
-  - `src/allographer/query_builder/models/mysql/mysql_exec.nim`
-  - `tests/mysql/test_prepared_statement.nim`
-- SQLite 実装
+- 既存 prepared statement API
   - `src/allographer/query_builder/models/sqlite/sqlite_types.nim`
   - `src/allographer/query_builder/models/sqlite/sqlite_exec.nim`
-  - `tests/sqlite/test_prepared_statement.nim`
-- benchmark
-  - `example/benchmark.nim`
+  - `src/allographer/query_builder/models/postgres/postgres_types.nim`
+  - `src/allographer/query_builder/models/postgres/postgres_exec.nim`
+  - `src/allographer/query_builder/models/mysql/mysql_exec.nim`
+  - `src/allographer/query_builder/models/mariadb/mariadb_exec.nim`
+- 現在の SurrealDB 実装
+  - `src/allographer/query_builder/models/surreal/surreal_types.nim`
+  - `src/allographer/query_builder/models/surreal/surreal_exec.nim`
+  - `src/allographer/query_builder/models/surreal/surreal_open.nim`
+  - `src/allographer/query_builder/libs/surreal/surreal_impl.nim`
+  - `src/allographer/query_builder/libs/surreal/surreal_lib.nim`
+  - `src/allographer/schema_builder/queries/surreal/schema_utils.nim`
+- 既存ドキュメント
+  - `documents/surrealdb/query_builder.md`
+  - `documents/surrealdb/schema_builder.md`
+- SurrealDB v3 公式ドキュメント
+  - Parameters: https://surrealdb.com/docs/surrealql/parameters
+  - HTTP Protocol (`POST /sql`): https://surrealdb.com/docs/surrealdb/integration/http
+  - Transactions: https://surrealdb.com/docs/surrealql/transactions
+  - Security summary (parameterized query): https://surrealdb.com/docs/surrealdb/security/summary
 
 ## 調査結果・設計まとめ
 
-### 1. PostgreSQL 側で実装済みの内容
+### 1. 前提整理
 
-`333-prepared-statement` に書かれていた PostgreSQL 向け主要タスクは、コードベース上かなり進んでいる。
+SurrealDB v3 には PostgreSQL や MySQL のような server-side prepared statement を、そのまま同じ意味で `/sql` HTTP 経由に載せる公開 API は見当たらない。一方で、以下は公式仕様として確認できる。
 
-- `Connections.preparedCache` が追加済み
-- `prepare()` は SQL 単位で cache entry を引く形になっている
-- `close()` は logical close になっており、entry の refCount を下げるだけになっている
-- 物理破棄 API として `flushStmt(sql)` / `clearStmtCache()` が入っている
-- 接続固定 API は設計書の `withPreparedConnection` ではなく `withConn` という名前で実装済み
-- `PostgresPreparedContext` と、`get/first/getPlain/firstPlain/exec` の `ctx` overload が実装済み
-- benchmark は prepared cold / warm に分かれており、PostgreSQL では `withConn` を使う分岐が入っている
-- PostgreSQL テストには logical close、cache clear、接続固定 API の確認が追加済み
+- `/sql` は 1 回の POST で複数の SurrealQL 文を `;` 区切りで送れる
+- parameter は `LET $x = ...;` で定義して後続文から参照できる
+- SurrealDB 3.x では `$x = ...` だけの旧記法は deprecated で、`LET` を使う必要がある
+- statement はデフォルトで文ごとに transaction 境界を持つ。複数文を原子的に扱いたい場合は `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` が必要
 
-### 2. PostgreSQL 側で未完了または名称確定済みの点
+したがって、このブランチでの `prepare()` は「DB が statement を事前コンパイルして保持する API」ではなく、「SQL template の正規化・再利用・安全な値埋め込み・単一 request 化を行う client-side prepared statement」として設計する。
 
-`333-prepared-statement` の設計と完全一致ではない点が残っている。
+### 2. 公開 API 方針
 
-- 接続固定 API 名は `withConn` を正とする
-- cache clear API 名は `clearStmtCache` を正とする
-- eviction / `preparedCacheMaxEntries` / LRU の Phase 3 は未実装
-- 「physical prepare が 1 回に収まること」を直接見るテストはまだ入っていない
+利用者体験は既存 driver に寄せる。第一候補は次の API である。
 
-このブランチではまず MariaDB / MySQL への API 横展開を優先し、PostgreSQL の高度な eviction は別タスクとして扱う。
+```nim
+let stmt = surreal.prepare("SELECT * FROM user WHERE id = ?")
+let rows = await stmt.get(@["user:alice"])
+let row = await stmt.first(%*[1])
+await stmt.exec(@["value"])
+await stmt.close()
+await surreal.clearStmtCache()
+await surreal.withConn(proc(ctx: SurrealPreparedContext): Future[void] {.async.} =
+  discard await stmt.first(ctx, @["user:alice"])
+)
+```
 
-### 3. MariaDB / MySQL 側の現状
+採用方針:
 
-MariaDB / MySQL の prepared statement 実装は、まだ PostgreSQL 以前の形に近い。
+- `prepare`
+- `get`
+- `first`
+- `exec`
+- `close`
+- `flushStmt`
+- `clearStmtCache`
+- `withConn`
+- `SurrealPreparedContext`
 
-- prepared statement ハンドル自身が `stmts: seq[PSTMT]` を持つ
-- `prepare()` は毎回新しいハンドルを返し、プール単位 cache は持っていない
-- `close()` は各 `PSTMT` を物理 close する
-- 接続固定 API がない
-- prepared statement の `ctx` 付き overload がない
-- benchmark の warm 経路は PostgreSQL 以外ではフォールバック実行になっている
-- テストは基本的な select / update 程度で、logical close や cache 維持、接続固定 API は未検証
+初期スコープでは `getPlain` / `firstPlain` は後回し候補とする。SurrealDB の戻り値は object 中心で列定義が RDB より弱く、列順の意味が薄いため、まずは既存の `JsonNode` 中心 API を優先する。
 
-### 3.5 SQLite 側の現状
+### 3. 実装モデル
 
-SQLite の prepared statement 実装も、考え方としては MariaDB / MySQL の旧来実装に近い。
+prepared statement 実行時は、毎回次の 3 段階で 1 リクエストを組み立てる。
 
-- prepared statement ハンドル自身が `stmts: seq[PStmt]` を持つ
-- `prepare()` は毎回新しいハンドルを返し、プール単位 cache は持っていない
-- `close()` は各 `PStmt` を `finalize()` する物理 close である
-- `withConn` や `SqlitePreparedContext` は存在しない
-- prepared statement の `ctx` 付き overload はない
-- benchmark の warm 経路では SQLite は接続固定経路を使わず、通常の prepared 呼び出しへフォールバックする
+1. 元 SQL の `?` を `$a`, `$b`, ... に変換する
+2. 各引数を `LET $a = ...; LET $b = ...;` に変換する
+3. `LET` 群と本体 SQL を `;` で連結して `/sql` に 1 回だけ POST する
 
-SQLite は server-side prepare を持たないが、公開 API を PostgreSQL / MariaDB / MySQL と揃える価値は高いので、このブランチでは「同じ API で使えること」を主眼に設計を寄せる。
+概念的には次の形になる。
 
-### 4. このブランチの実装方針
+```sql
+LET $a = "user:alice";
+LET $b = <datetime>"2026-04-03T00:00:00Z";
+SELECT * FROM user WHERE id = $a AND created_at >= $b;
+```
 
-公開 API は PostgreSQL に寄せる。命名は「短く、意味が通じる」方を正とし、すでに PostgreSQL で使われている短い名前へ揃える。
+この方式なら、すでに `surreal_lib.nim` にある `questionToDaller` と `dbFormat(queryString, args: JsonNode)` の思想をそのまま再利用できる。prepared statement 専用に別の埋め込み規則を増やす必要はない。
 
-統一方針:
+### 4. 型設計
 
-- 接続固定 API は全 driver で `withConn`
-- prepared context 型は driver ごとに `MariadbPreparedContext` / `MysqlPreparedContext` / `SqlitePreparedContext`
-- cache clear API は全 driver で `clearStmtCache`
-- 個別破棄 API は全 driver で `flushStmt`
-- prepared statement の `close()` は全 driver で logical close
+既存 driver に合わせ、プール単位 cache を持つ。
 
-この形なら `example/benchmark.nim` の warm 経路を driver ごとに似た形へ揃えやすい。
+```nim
+type SurrealPreparedEntry = ref object
+  sql*: string
+  normalizedSql*: string
+  nArgs*: int
+  refCount*: int
+  lastUsedAt*: int64
 
-SQLite については driver 特性上、cache entry が保持する実体は `PStmt` になり、物理破棄は `finalize()` を使う。ただし利用者から見える API は PostgreSQL / MariaDB / MySQL と同じに保つ。
+type Connections* = ref object
+  conns*: seq[Connection]
+  timeout*: int
+  waiters*: Deque[Future[void]]
+  preparedCache*: Table[string, SurrealPreparedEntry]
 
-### 5. 実装後の確認
+type SurrealPreparedContext* = ref object
+  owner*: SurrealConnections
+  connI*: int
 
-- MariaDB / MySQL でも `Connections.preparedCache` を持ち、SQL ごとに `PSTMT` を再利用するようにした
-- `close()` は MariaDB / MySQL でも論理 close に変更し、物理破棄は `flushStmt` / `clearStmtCache` に分離した
-- `withConn` と `MariadbPreparedContext` / `MysqlPreparedContext` を追加し、benchmark の warm 経路を共通化した
-- prepared statement の `ctx` 付き overload を追加し、MariaDB / MySQL テストでも接続固定経路を検証するようにした
-- `example/benchmark.nim` は PostgreSQL / MariaDB / MySQL で同じ warm パターンを選べるようになった
-- SQLite も同じ `withConn` パターンで warm prepared 経路を通すようにした
-- 次の横展開先として SQLite を扱う方針を明文化した
-- SQLite では `PStmt` の lifecycle を `preparedCache` / `flushStmt` / `clearStmtCache` へ寄せつつ、公開 API は他 driver と共通化する方針とする
+type SurrealPreparedStatement* = ref object
+  owner*: SurrealConnections
+  entry*: SurrealPreparedEntry
+  sql*: string
+  isClosed*: bool
+```
 
-### 6. 実装順序
+ポイント:
+
+- Surreal は HTTP `/sql` なので physical statement handle は持たない
+- cache の目的は server resource 再利用ではなく、template 正規化と API 一貫性の維持
+- `close()` は logical close とし、cache entry 自体は `flushStmt` / `clearStmtCache` まで残す
+
+### 5. 実行結果の扱い
+
+`/sql` の戻り値は statement ごとの配列なので、prepared statement では「最後の本体 SQL の結果」を利用者へ返す。
+
+- `get`: 最終 statement の `result` を `seq[JsonNode]` で返す
+- `first`: `get` の先頭 1 件を `Option[JsonNode]` で返す
+- `exec`: 最終 statement の status を確認し、副作用系として扱う
+- `LET` statement の result は利用者に見せない
+
+ただし error 判定は最後の statement だけでなく全 statement を走査する。`LET` で失敗した場合でも早期に `DbError` を返す必要がある。
+
+### 6. `withConn` を残す理由
+
+HTTP `/sql` だけを見ると、prepared statement は connection 固定が必須ではない。しかし API 統一のため、`withConn` は残す価値がある。
+
+- 既存 driver と同じ呼び出しパターンを維持できる
+- SurrealDB の parameter は connection/session scope を持ちうるため、将来 RPC 対応や session 前提最適化へ進む余地を残せる
+- 現行の connection pool 制御と整合する
+
+ただし初期実装では、`withConn` の主目的は性能よりも API 一貫性になる。
+
+### 7. multi-statement 利用の境界
+
+このブランチで使う multi-statement は「`LET` 群 + 本体 SQL」を 1 リクエストに束ねる用途を主眼とする。
+
+- `prepare("UPDATE ...")` は 1 つの本体 statement を持つ
+- `LET` は前置 statement
+- 複数の業務 statement を 1 個の prepared statement に詰め込む設計は初期スコープ外
+
+理由:
+
+- 既存 prepared statement API も基本は 1 SQL を対象にしている
+- SurrealDB では複数 statement が自動で 1 transaction にはならない
+- 2 個以上の副作用文を 1 本の prepared statement に許すと、`exec()` の返り値・失敗時意味論・テストが急に複雑になる
+
+もし将来 multi-statement business query を扱うなら、別 API として `prepareBatch` あるいは transaction helper を検討する。
+
+### 8. 実装順序
 
 #### Phase 1
 
-- MariaDB / MySQL の型定義に prepared cache entry と context 型を追加する
-- `Connections` に prepared cache を持たせる
-- `prepare()` を SQL 単位 cache lookup ベースへ変更する
+- `surreal_types.nim` に prepared 関連型を追加する
+- `Connections` に `preparedCache` を追加する
+- `prepare()` / `close()` / `flushStmt()` / `clearStmtCache()` の骨格を追加する
 
 #### Phase 2
 
-- MariaDB / MySQL の `close()` を logical close に変える
-- `flushStmt` / `clearStmtCache` を追加する
-- 接続 close 時に物理 prepared state が自然破棄される前提との差分を確認する
+- `surreal_lib.nim` の placeholder 変換を prepared statement でも使える形に整理する
+- `surreal_impl.nim` に multi-statement response 検証の共通処理を追加する
+- `get` / `first` / `exec` を実装する
 
 #### Phase 3
 
-- MariaDB / MySQL に `withConn` を追加する
-- prepared statement の `ctx` overload を追加する
-- benchmark の warm 経路を PostgreSQL と同じ書き方へ寄せる
+- `withConn` / `SurrealPreparedContext` を追加する
+- `ctx` 付き overload を実装する
+- `tests/surrealdb/test_prepared_statement.nim` を追加する
 
 #### Phase 4
 
-- MariaDB / MySQL テストを拡張する
-- logical close 後の再利用
-- cache clear 後の再 prepare
-- 接続固定 API 経由の select / update
-- transaction 中の接続選択との整合
+- 必要なら `documents/surrealdb/query_builder.md` に prepared statement の使い方を追記する
+- `schema_builder` 側の逐次 `/sql` 実行を将来的に batch 化できるか別タスクで評価する
 
-#### Phase 5
+### 9. テスト方針
 
-- SQLite の型定義に prepared cache entry と context 型を追加する
-- `Connections` に prepared cache を持たせる
-- `prepare()` を SQL 単位 cache lookup ベースへ変更する
-- `close()` を logical close に変え、`flushStmt` / `clearStmtCache` を追加する
-- SQLite に `withConn` を追加する
-- prepared statement の `ctx` overload を追加する
-- benchmark の warm 経路を SQLite でも同じ書き方へ寄せる
-- SQLite テストを logical close、cache clear、接続固定 API まで拡張する
+- `prepare("SELECT ... WHERE id = ?")` で `get` / `first` が通ること
+- `prepare("UPDATE ... SET name = ? WHERE id = ?")` で `exec` が通ること
+- `close()` 後に同じ SQL を `prepare()` し直しても再利用できること
+- `clearStmtCache()` 後に再度 `prepare()` できること
+- `withConn` 内の `ctx` overload が通ること
+- `JsonNode` 引数で `JInt` / `JString` / `JNull` / `JArray` / `JObject` が `LET` 経由で正しく扱えること
+- record id や datetime 文字列の変換が既存 `dbFormat` 規則と一致すること
 
-### 7. 注意点
+### 10. 現時点の結論
 
-- `SYW-ARCH-001` / `SYW-ARCH-002` に従い、driver 差分を公開 API に漏らしすぎない
-- 既存の MariaDB / MySQL prepared statement API を壊す場合は移行影響を記録する
-- SQLite は driver 特性上 server-side state を持たないため、「PostgreSQL と同じ内部実装」ではなく「同じ公開 API と同じ利用体験」を揃える
-- 現時点で PostgreSQL は `withConn` / `clearStmtCache` 命名で先行しており、この命名を正式採用する
-- 実装中に PostgreSQL 側の API 名を再調整したくなった場合は、この文書の設計方針も合わせて更新する
+SurrealDB v3 版 prepared statement は「server-side prepare の移植」ではなく、「既存 prepared statement API と揃った公開インターフェースを、SurrealDB の `LET` と `/sql` multi-statement で安全に再現する」方針が最も自然である。
+
+この方針なら `SYW-ARCH-001` に従って公開 API を共通化しつつ、SurrealDB 固有差分は `libs/surreal` と `models/surreal` に閉じ込められる。

--- a/documents/rdb/query_builder.md
+++ b/documents/rdb/query_builder.md
@@ -686,6 +686,8 @@ await selectStmt.close()
 await updateStmt.close()
 ```
 
+SurrealDB では server-side prepare ではなく、`LET` を使った client-side template reuse として同じ API を提供します。
+
 In PostgreSQL, a context API can be used to ensure multiple operations use the same connection.
 
 ```nim

--- a/documents/surrealdb/prepared_statement.md
+++ b/documents/surrealdb/prepared_statement.md
@@ -1,0 +1,77 @@
+Example: Prepared Statement for SurrealDB
+===
+> [!WARNING]
+> SurrealDB の prepared statement は server-side prepare ではなく、client-side template reuse と `/sql` の multi-statement 実行で再現しています。
+
+[back](../../README.md)
+
+## index
+<!--ts-->
+* [Example: Prepared Statement for SurrealDB](#example-prepared-statement-for-surrealdb)
+   * [index](#index)
+   * [About](#about)
+   * [Create Connection](#create-connection)
+   * [prepare](#prepare)
+   * [withConn](#withconn)
+   * [Cache Control](#cache-control)
+<!--te-->
+
+---
+
+## About
+[SurrealDB official docs](https://surrealdb.com/docs)
+
+Prepared statement の公開 API は他 driver に寄せていますが、SurrealDB では内部的に次の形へ展開します。
+
+```sql
+LET $a = "user:alice";
+SELECT * FROM "user" WHERE "id" = $a;
+```
+
+`?` は `$a`, `$b`, ... に変換され、引数は `LET` で前置されます。これにより、1 リクエストで安全に再利用できるテンプレートとして扱えます。
+
+## Create Connection
+
+```nim
+import std/asyncdispatch
+import allographer/connection
+
+let surreal = dbOpen(SurrealDB, "test", "test", "user", "pass", "http://surreal", 8000, 5, 30, false, false).await
+```
+
+## prepare
+
+```nim
+import std/asyncdispatch
+import std/json
+import allographer/query_builder
+
+let stmt = surreal.prepare("""SELECT * FROM "user" WHERE "id" = ?""")
+let rows = await stmt.get(@["user:alice"])
+let row = await stmt.first(@["user:alice"])
+await stmt.exec(@["user:alice"])
+await stmt.close()
+```
+
+`close()` は logical close です。SurrealDB 側に物理 prepared handle はないため、キャッシュの整理は `flushStmt()` / `clearStmtCache()` で行います。
+
+## withConn
+
+```nim
+await surreal.withConn(
+  proc(ctx: SurrealPreparedContext): Future[void] {.async.} =
+    discard await stmt.first(ctx, @["user:alice"])
+    await stmt.exec(ctx, @["user:alice"])
+)
+```
+
+`withConn()` は同じ connection index を使い回したいときの API です。将来の session 前提最適化や transaction helper とも相性がよい形にしてあります。
+
+## Cache Control
+
+```nim
+await surreal.flushStmt(stmt)
+await surreal.clearStmtCache()
+```
+
+`flushStmt(stmt)` はその prepared statement を閉じて、対応するテンプレートをキャッシュから外します。`clearStmtCache()` はキャッシュ全体を空にします。

--- a/documents/surrealdb/query_builder.md
+++ b/documents/surrealdb/query_builder.md
@@ -28,6 +28,7 @@ Example: Query Builder for SurrealDB
    * [delete all](#delete-all)
    * [delete row](#delete-row)
    * [Raw Query](#raw-query)
+   * [Prepared Statement](#prepared-statement)
    * [Aggregates](#aggregates)
       * [count](#count)
       * [max](#max)
@@ -478,6 +479,17 @@ echo rows
     "string":"aaa"
   }
 ]
+```
+
+## Prepared Statement
+[to index](#INDEX)
+
+SurrealDB の prepared statement は [`documents/surrealdb/prepared_statement.md`](./prepared_statement.md) にまとめています。`prepare()`, `get()`, `first()`, `exec()`, `close()`, `flushStmt(stmt)`, `clearStmtCache()`, `withConn()` が利用できます。
+
+```nim
+let stmt = surreal.prepare("""SELECT * FROM "type" WHERE "id" = ?""")
+let row = await stmt.first(@["type:9nxye3dons0juyelv5if"])
+await stmt.close()
 ```
 
 ## Aggregates

--- a/example/benchmark.nim
+++ b/example/benchmark.nim
@@ -127,6 +127,30 @@ template benchmarkScenario(rdb: untyped, useBackticks: static[bool]): untyped =
                 discard await selectStmtWarm.first(ctx, @[$index])
                 await updateStmtWarm.exec(ctx, @[$number, $index])
             )
+          elif declared(MariadbPreparedContext) and compiles(
+            rdb.withConn(
+              proc(ctx: MariadbPreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
+          ):
+            await rdb.withConn(
+              proc(ctx: MariadbPreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
+          elif declared(MysqlPreparedContext) and compiles(
+            rdb.withConn(
+              proc(ctx: MysqlPreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
+          ):
+            await rdb.withConn(
+              proc(ctx: MysqlPreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
           else:
             discard await selectStmtWarm.first(@[$index])
             await updateStmtWarm.exec(@[$number, $index])

--- a/example/benchmark.nim
+++ b/example/benchmark.nim
@@ -151,6 +151,18 @@ template benchmarkScenario(rdb: untyped, useBackticks: static[bool]): untyped =
                 discard await selectStmtWarm.first(ctx, @[$index])
                 await updateStmtWarm.exec(ctx, @[$number, $index])
             )
+          elif declared(SqlitePreparedContext) and compiles(
+            rdb.withConn(
+              proc(ctx: SqlitePreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
+          ):
+            await rdb.withConn(
+              proc(ctx: SqlitePreparedContext): Future[void] {.async.} =
+                discard await selectStmtWarm.first(ctx, @[$index])
+                await updateStmtWarm.exec(ctx, @[$number, $index])
+            )
           else:
             discard await selectStmtWarm.first(@[$index])
             await updateStmtWarm.exec(@[$number, $index])

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 exec:
-	docker compose up -d
+	docker compose start
 	docker compose exec app bash
 
 stop:

--- a/src/allographer/connection.nim
+++ b/src/allographer/connection.nim
@@ -8,15 +8,15 @@ when isExistsSqlite:
   import ./query_builder/models/sqlite/sqlite_open; export sqlite_open
 
 when isExistsPostgres:
-  import ./query_builder/models/postgres/postgres_types; export PostgreSQL, PostgresConnections
+  import ./query_builder/models/postgres/postgres_types; export PostgreSQL, PostgresConnections, PostgresPreparedContext
   import ./query_builder/models/postgres/postgres_open; export postgres_open
 
 when isExistsMariadb:
-  import ./query_builder/models/mariadb/mariadb_types; export MariaDB, MariadbConnections
+  import ./query_builder/models/mariadb/mariadb_types; export MariaDB, MariadbConnections, MariadbPreparedContext
   import ./query_builder/models/mariadb/mariadb_open; export mariadb_open
 
 when isExistsMysql:
-  import ./query_builder/models/mysql/mysql_types; export MySql, MysqlConnections
+  import ./query_builder/models/mysql/mysql_types; export MySql, MysqlConnections, MysqlPreparedContext
   import ./query_builder/models/mysql/mysql_open; export mysql_open
 
 when isExistsSurrealdb:

--- a/src/allographer/connection.nim
+++ b/src/allographer/connection.nim
@@ -4,7 +4,7 @@ import ./query_builder/libs/database_url
 export DatabaseUrl, DatabaseUrlQuery, ParsedDatabaseUrl, asDatabaseUrl, parseDatabaseUrl, databaseName, sqliteDatabasePath, portOrDefault, requireDatabaseUrlScheme
 
 when isExistsSqlite:
-  import ./query_builder/models/sqlite/sqlite_types; export SQLite3, SqliteConnections
+  import ./query_builder/models/sqlite/sqlite_types; export SQLite3, SqliteConnections, SqlitePreparedContext
   import ./query_builder/models/sqlite/sqlite_open; export sqlite_open
 
 when isExistsPostgres:

--- a/src/allographer/connection.nim
+++ b/src/allographer/connection.nim
@@ -20,5 +20,5 @@ when isExistsMysql:
   import ./query_builder/models/mysql/mysql_open; export mysql_open
 
 when isExistsSurrealdb:
-  import ./query_builder/models/surreal/surreal_types; export SurrealDB, SurrealConnections
+  import ./query_builder/models/surreal/surreal_types; export SurrealDB, SurrealConnections, SurrealPreparedContext
   import ./query_builder/models/surreal/surreal_open; export surreal_open

--- a/src/allographer/query_builder.nim
+++ b/src/allographer/query_builder.nim
@@ -6,7 +6,7 @@ import ./query_builder/error; export error
 import ./query_builder/models/orm; export orm
 
 when isExistsSqlite:
-  import ./query_builder/models/sqlite/sqlite_types; export sqlite_types
+  import ./query_builder/models/sqlite/sqlite_types; export SQLite3, SqliteConnections, SqlitePreparedContext, sqlite_types
   import ./query_builder/models/sqlite/sqlite_query; export sqlite_query
   import ./query_builder/models/sqlite/sqlite_exec; export sqlite_exec
   import ./query_builder/models/sqlite/sqlite_transaction; export sqlite_transaction

--- a/src/allographer/query_builder/libs/surreal/surreal_lib.nim
+++ b/src/allographer/query_builder/libs/surreal/surreal_lib.nim
@@ -166,9 +166,19 @@ proc appendJsonLetClause(result: var string, idx: int, arg: JsonNode, quoteStrin
   result.add("; ")
 
 
-proc dbFormat*(queryString: string, args: JsonNode): string =
-  let queryPart = queryString.questionToDaller()
-  result = newStringOfCap(queryPart.len + max(args.len, 1) * 24)
+proc dbFormatPrepared*(normalizedQueryString: string, args: JsonNode): string =
+  ## `normalizedQueryString` should already have `?` converted to SurrealQL
+  ## style placeholders.
+  if args.isNil:
+    result = newStringOfCap(normalizedQueryString.len)
+    result.add(normalizedQueryString)
+    return
+  if args.kind == JNull:
+    result = newStringOfCap(normalizedQueryString.len)
+    result.add(normalizedQueryString)
+    return
+
+  result = newStringOfCap(normalizedQueryString.len + max(args.len, 1) * 24)
   if args.kind == JArray and args.len > 0:
     var i = 1
     for arg in args.items:
@@ -176,8 +186,12 @@ proc dbFormat*(queryString: string, args: JsonNode): string =
       inc(i)
   elif args.kind == JObject and args.len > 0:
     var i = 1
-    for (key, arg) in args.pairs:
+    for (_, arg) in args.pairs:
       appendJsonLetClause(result, i, arg, false)
       inc(i)
 
-  result.add(queryPart)
+  result.add(normalizedQueryString)
+
+
+proc dbFormat*(queryString: string, args: JsonNode): string =
+  result = dbFormatPrepared(queryString.questionToDaller(), args)

--- a/src/allographer/query_builder/models/mariadb/mariadb_exec.nim
+++ b/src/allographer/query_builder/models/mariadb/mariadb_exec.nim
@@ -63,20 +63,60 @@ proc raisePoolTimeout(self: MariadbConnections | MariadbQuery | RawMariadbQuery 
   raise newException(DbError, "Timed out while waiting for a free MariaDB connection")
 
 
+proc touchStmtEntry(entry: MariadbPreparedEntry) =
+  entry.lastUsedAt = getTime().toUnix()
+
+
+proc mustBeOpen(self: MariadbPreparedStatement) =
+  if self.isNil or self.isClosed:
+    raise newException(DbError, "MariaDB prepared statement is already closed")
+
+
+proc hasPreparedEntry(cache: Table[string, MariadbPreparedEntry], sql: string): bool =
+  for key in cache.keys:
+    if key == sql:
+      return true
+  return false
+
+
+proc getStmtEntry(self: MariadbConnections, sql: string): MariadbPreparedEntry =
+  if hasPreparedEntry(self.pools.preparedCache, sql):
+    return self.pools.preparedCache[sql]
+  let entry = MariadbPreparedEntry(
+    sql: sql,
+    nArgs: countQuestionMarks(sql),
+    stmts: newSeq[PSTMT](self.pools.conns.len),
+    refCount: 0,
+    lastUsedAt: getTime().toUnix(),
+  )
+  self.pools.preparedCache[sql] = entry
+  return entry
+
+
 proc prepare*(self: MariadbConnections, sql: string): MariadbPreparedStatement =
   new(result)
   result.owner = self
   result.info = self.info
+  result.entry = self.getStmtEntry(sql)
   result.sql = sql
-  result.stmts = newSeq[PSTMT](self.pools.conns.len)
-  result.nArgs = countQuestionMarks(sql)
+  result.nArgs = result.entry.nArgs
+  result.entry.refCount += 1
+  touchStmtEntry(result.entry)
   result.resultBindCache = newSeq[MariadbResultBindCache](self.pools.conns.len)
 
 
 proc ensurePreparedStmt(self: MariadbPreparedStatement, connI: int): Future[PSTMT] {.async.} =
-  if self.stmts[connI].isNil:
-    self.stmts[connI] = await mariadb_impl.prepareStmt(self.owner.pools.conns[connI].conn, self.sql, self.owner.pools.timeout)
-  return self.stmts[connI]
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MariaDB prepared statement received an invalid connection index")
+  if self.entry.stmts[connI].isNil:
+    self.entry.stmts[connI] = await mariadb_impl.prepareStmt(
+      self.owner.pools.conns[connI].conn,
+      self.sql,
+      self.owner.pools.timeout
+    )
+  touchStmtEntry(self.entry)
+  return self.entry.stmts[connI]
 
 
 # ================================================================================
@@ -399,15 +439,43 @@ proc transactionEnd(self:MariadbConnections, query:string) {.async.} =
   mariadb_impl.exec(self.pools.conns[self.transactionConn].conn, query, newJArray(), newSeq[seq[string]](), self.pools.timeout).await
 
 
-proc getPreparedRows(self: MariadbPreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
-  var connI = self.owner.transactionConn
-  if not self.owner.isInTransaction:
-    connI = getFreeConn(self.owner).await
-  defer:
-    if not self.owner.isInTransaction:
-      self.owner.returnConn(connI).await
+proc withConn*(
+  self: MariadbConnections,
+  body: proc (ctx: MariadbPreparedContext): Future[void]
+) {.async.} =
+  if self.isInTransaction:
+    let ctx = MariadbPreparedContext(owner: self, connI: self.transactionConn)
+    await body(ctx)
+    return
+
+  let connI = getFreeConn(self).await
   if connI == errorConnectionNum:
     raisePoolTimeout(self)
+  defer:
+    self.returnConn(connI).await
+
+  let ctx = MariadbPreparedContext(owner: self, connI: connI)
+  await body(ctx)
+
+
+proc verifyCtx(self: MariadbPreparedStatement, ctx: MariadbPreparedContext) =
+  self.mustBeOpen()
+  if ctx.isNil:
+    raise newException(DbError, "MariaDB prepared context is nil")
+  if ctx.owner != self.owner:
+    raise newException(DbError, "MariaDB prepared context owner mismatch")
+  if ctx.connI < 0 or ctx.connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MariaDB prepared context has invalid connection index")
+
+
+proc getPreparedRowsOnConn(
+  self: MariadbPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MariaDB prepared statement received an invalid connection index")
 
   let stmt = await self.ensurePreparedStmt(connI)
   if connI >= self.resultBindCache.len:
@@ -421,6 +489,31 @@ proc getPreparedRows(self: MariadbPreparedStatement, args: seq[PreparedParam]): 
     self.owner.pools.timeout,
     self.resultBindCache[connI]
   ).await
+
+
+proc getPreparedRows(
+  self: MariadbPreparedStatement,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  var connI = self.owner.transactionConn
+  if not self.owner.isInTransaction:
+    connI = getFreeConn(self.owner).await
+  defer:
+    if not self.owner.isInTransaction:
+      self.owner.returnConn(connI).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+
+  return await self.getPreparedRowsOnConn(connI, args)
+
+
+proc getPreparedRows(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.verifyCtx(ctx)
+  return await self.getPreparedRowsOnConn(ctx.connI, args)
 
 
 proc getPreparedAllRows(self: MariadbPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
@@ -452,6 +545,69 @@ proc getPreparedRowPlain(self: MariadbPreparedStatement, args: seq[PreparedParam
   return rows[0]
 
 
+proc getPreparedAllRows(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[JsonNode](0)
+  return toJson(rows, dbRows)
+
+
+proc getPreparedRow(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return none(JsonNode)
+  return toJson(rows, dbRows)[0].some()
+
+
+proc getPreparedAllRowsPlain(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  let (rows, _) = await self.getPreparedRows(ctx, args)
+  return rows
+
+
+proc getPreparedRowPlain(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  let (rows, _) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[string](0)
+  return rows[0]
+
+
+proc execPreparedOnConn(
+  self: MariadbPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MariaDB prepared statement received an invalid connection index")
+
+  let stmt = await self.ensurePreparedStmt(connI)
+  await mariadb_impl.execPreparedStmt(
+    self.owner.pools.conns[connI].conn,
+    stmt,
+    args,
+    self.owner.pools.timeout
+  )
+
+
 proc execPrepared(self: MariadbPreparedStatement, args: seq[PreparedParam]) {.async.} =
   var connI = self.owner.transactionConn
   if not self.owner.isInTransaction:
@@ -462,13 +618,16 @@ proc execPrepared(self: MariadbPreparedStatement, args: seq[PreparedParam]) {.as
   if connI == errorConnectionNum:
     raisePoolTimeout(self)
 
-  let stmt = await self.ensurePreparedStmt(connI)
-  await mariadb_impl.execPreparedStmt(
-    self.owner.pools.conns[connI].conn,
-    stmt,
-    args,
-    self.owner.pools.timeout
-  )
+  await self.execPreparedOnConn(connI, args)
+
+
+proc execPrepared(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.verifyCtx(ctx)
+  await self.execPreparedOnConn(ctx.connI, args)
 
 
 proc preparedGet(self: MariadbPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
@@ -521,44 +680,154 @@ proc preparedExec(self: MariadbPreparedStatement, args: seq[PreparedParam]) {.as
     raise getCurrentException()
 
 
+proc preparedGet(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedAllRows(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedFirst(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedGetPlain(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedAllRowsPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedFirstPlain(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRowPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedExec(
+  self: MariadbPreparedStatement,
+  ctx: MariadbPreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
 proc get*(self: MariadbPreparedStatement, args: seq[string]): Future[seq[JsonNode]] {.async.} =
   return await self.preparedGet(args.toPreparedParams)
+
+
+proc get*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: seq[string]): Future[seq[JsonNode]] {.async.} =
+  return await self.preparedGet(ctx, args.toPreparedParams)
 
 
 proc get*(self: MariadbPreparedStatement, args: JsonNode): Future[seq[JsonNode]] {.async.} =
   return await self.preparedGet(args.toPreparedParams)
 
 
+proc get*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  return await self.preparedGet(ctx, args.toPreparedParams)
+
+
 proc first*(self: MariadbPreparedStatement, args: seq[string]): Future[Option[JsonNode]] {.async.} =
   return await self.preparedFirst(args.toPreparedParams)
+
+
+proc first*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: seq[string]): Future[Option[JsonNode]] {.async.} =
+  return await self.preparedFirst(ctx, args.toPreparedParams)
 
 
 proc first*(self: MariadbPreparedStatement, args: JsonNode): Future[Option[JsonNode]] {.async.} =
   return await self.preparedFirst(args.toPreparedParams)
 
 
+proc first*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  return await self.preparedFirst(ctx, args.toPreparedParams)
+
+
 proc getPlain*(self: MariadbPreparedStatement, args: seq[string]): Future[seq[seq[string]]] {.async.} =
   return await self.preparedGetPlain(args.toPreparedParams)
+
+
+proc getPlain*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: seq[string]): Future[seq[seq[string]]] {.async.} =
+  return await self.preparedGetPlain(ctx, args.toPreparedParams)
 
 
 proc getPlain*(self: MariadbPreparedStatement, args: JsonNode): Future[seq[seq[string]]] {.async.} =
   return await self.preparedGetPlain(args.toPreparedParams)
 
 
+proc getPlain*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: JsonNode): Future[seq[seq[string]]] {.async.} =
+  return await self.preparedGetPlain(ctx, args.toPreparedParams)
+
+
 proc firstPlain*(self: MariadbPreparedStatement, args: seq[string]): Future[seq[string]] {.async.} =
   return await self.preparedFirstPlain(args.toPreparedParams)
+
+
+proc firstPlain*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: seq[string]): Future[seq[string]] {.async.} =
+  return await self.preparedFirstPlain(ctx, args.toPreparedParams)
 
 
 proc firstPlain*(self: MariadbPreparedStatement, args: JsonNode): Future[seq[string]] {.async.} =
   return await self.preparedFirstPlain(args.toPreparedParams)
 
 
+proc firstPlain*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: JsonNode): Future[seq[string]] {.async.} =
+  return await self.preparedFirstPlain(ctx, args.toPreparedParams)
+
+
 proc exec*(self: MariadbPreparedStatement, args: seq[string]) {.async.} =
   await self.preparedExec(args.toPreparedParams)
 
 
+proc exec*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: seq[string]) {.async.} =
+  await self.preparedExec(ctx, args.toPreparedParams)
+
+
 proc exec*(self: MariadbPreparedStatement, args: JsonNode) {.async.} =
   await self.preparedExec(args.toPreparedParams)
+
+
+proc exec*(self: MariadbPreparedStatement, ctx: MariadbPreparedContext, args: JsonNode) {.async.} =
+  await self.preparedExec(ctx, args.toPreparedParams)
 
 
 # ================================================================================
@@ -849,14 +1118,34 @@ proc firstPlain*(self: RawMariadbQuery):Future[seq[string]] {.async.} =
 
 
 proc close*(self: MariadbPreparedStatement) {.async.} =
-  for i, stmt in self.stmts:
+  if self.isNil or self.isClosed:
+    return
+  self.isClosed = true
+  if not self.entry.isNil:
+    if self.entry.refCount > 0:
+      self.entry.refCount -= 1
+    touchStmtEntry(self.entry)
+
+
+proc flushStmt*(self: MariadbConnections, sql: string) {.async.} =
+  if not hasPreparedEntry(self.pools.preparedCache, sql):
+    return
+  let entry = self.pools.preparedCache[sql]
+  for i, stmt in entry.stmts:
     if stmt.isNil:
       continue
     try:
       mariadb_impl.closePreparedStmt(stmt)
     except CatchableError:
-      self.owner.log.echoErrorMsg("close failed for prepared stmt: " & getCurrentExceptionMsg())
-    self.stmts[i] = nil
+      self.log.echoErrorMsg("close failed for prepared stmt: " & getCurrentExceptionMsg())
+    entry.stmts[i] = nil
+  self.pools.preparedCache.del(sql)
+
+
+proc clearStmtCache*(self: MariadbConnections) {.async.} =
+  let keys = toSeq(self.pools.preparedCache.keys)
+  for sql in keys:
+    await self.flushStmt(sql)
 
 
 template seeder*(rdb:MariadbConnections, tableName:string, body:untyped):untyped =

--- a/src/allographer/query_builder/models/mariadb/mariadb_open.nim
+++ b/src/allographer/query_builder/models/mariadb/mariadb_open.nim
@@ -1,3 +1,6 @@
+import std/asyncdispatch
+import std/deques
+import std/tables
 import std/times
 import ../../libs/database_url
 import ../../libs/mariadb/mariadb_rdb
@@ -30,7 +33,10 @@ proc dbOpen*(_: type MariaDB, database: string, user: string, password: string,
     )
   let pools = Connections(
     conns: conns,
-    timeout: timeout
+    timeout: timeout,
+    waiters: initDeque[Future[void]](),
+    columnTypeCache: initTable[string, seq[seq[string]]](),
+    preparedCache: initTable[string, MariadbPreparedEntry](),
   )
   let info = ConnectionInfo(
     database:database,

--- a/src/allographer/query_builder/models/mariadb/mariadb_types.nim
+++ b/src/allographer/query_builder/models/mariadb/mariadb_types.nim
@@ -23,11 +23,20 @@ type Connection* = object
   createdAt*: int64
 
 
+type MariadbPreparedEntry* = ref object
+  sql*: string
+  nArgs*: int
+  stmts*: seq[PSTMT]
+  refCount*: int
+  lastUsedAt*: int64
+
+
 type Connections* = ref object
   conns*: seq[Connection]
   timeout*:int
   waiters*: Deque[Future[void]]
   columnTypeCache*: Table[string, seq[seq[string]]]
+  preparedCache*: Table[string, MariadbPreparedEntry]
 
 
 ## created by `let rdb = dbOpen(MySQL, "localhost", 3306)`
@@ -38,6 +47,11 @@ type MariadbConnections* = ref object
   # for transaction
   isInTransaction*: bool
   transactionConn*: int
+
+
+type MariadbPreparedContext* = ref object
+  owner*: MariadbConnections
+  connI*: int
 
 
 ## created by `rdb.select("columnName")` or `rdb.table("tableName")`
@@ -76,9 +90,10 @@ type MariadbResultBindCache* = ref object
 type MariadbPreparedStatement* = ref object
   owner*: MariadbConnections
   info*: ConnectionInfo
+  entry*: MariadbPreparedEntry
   sql*: string
-  stmts*: seq[PSTMT]
   nArgs*: int
+  isClosed*: bool
   resultBindCache*: seq[MariadbResultBindCache]
 
 

--- a/src/allographer/query_builder/models/mysql/mysql_exec.nim
+++ b/src/allographer/query_builder/models/mysql/mysql_exec.nim
@@ -4,6 +4,7 @@ import std/options
 import std/strformat
 import std/strutils
 import std/sequtils
+import std/tables
 import std/times
 import ../../error
 import ../../libs/mysql/mysql_impl
@@ -40,6 +41,36 @@ proc returnConn(self:MysqlConnections | MysqlQuery | RawMysqlQuery, i: int) {.as
 
 proc raisePoolTimeout(self: MysqlConnections | MysqlQuery | RawMysqlQuery | MysqlPreparedStatement) {.noreturn.} =
   raise newException(DbError, "Timed out while waiting for a free MySQL connection")
+
+
+proc touchStmtEntry(entry: MysqlPreparedEntry) =
+  entry.lastUsedAt = getTime().toUnix()
+
+
+proc mustBeOpen(self: MysqlPreparedStatement) =
+  if self.isNil or self.isClosed:
+    raise newException(DbError, "MySQL prepared statement is already closed")
+
+
+proc hasPreparedEntry(cache: Table[string, MysqlPreparedEntry], sql: string): bool =
+  for key in cache.keys:
+    if key == sql:
+      return true
+  return false
+
+
+proc getStmtEntry(self: MysqlConnections, sql: string): MysqlPreparedEntry =
+  if hasPreparedEntry(self.pools.preparedCache, sql):
+    return self.pools.preparedCache[sql]
+  let entry = MysqlPreparedEntry(
+    sql: sql,
+    nArgs: countQuestionMarks(sql),
+    stmts: newSeq[PSTMT](self.pools.conns.len),
+    refCount: 0,
+    lastUsedAt: getTime().toUnix(),
+  )
+  self.pools.preparedCache[sql] = entry
+  return entry
 
 
 # ================================================================================
@@ -613,31 +644,69 @@ proc commit*(self:MysqlConnections) {.async.} =
   self.transactionEnd("COMMIT").await
 
 
+proc withConn*(
+  self: MysqlConnections,
+  body: proc (ctx: MysqlPreparedContext): Future[void]
+) {.async.} =
+  if self.isInTransaction:
+    let ctx = MysqlPreparedContext(owner: self, connI: self.transactionConn)
+    await body(ctx)
+    return
+
+  let connI = getFreeConn(self).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  defer:
+    self.returnConn(connI).await
+
+  let ctx = MysqlPreparedContext(owner: self, connI: connI)
+  await body(ctx)
+
+
+proc verifyCtx(self: MysqlPreparedStatement, ctx: MysqlPreparedContext) =
+  self.mustBeOpen()
+  if ctx.isNil:
+    raise newException(DbError, "MySQL prepared context is nil")
+  if ctx.owner != self.owner:
+    raise newException(DbError, "MySQL prepared context owner mismatch")
+  if ctx.connI < 0 or ctx.connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MySQL prepared context has invalid connection index")
+
+
 proc prepare*(self: MysqlConnections, sql: string): MysqlPreparedStatement =
   new(result)
   result.owner = self
   result.info = self.info
+  result.entry = self.getStmtEntry(sql)
   result.sql = sql
-  result.stmts = newSeq[PSTMT](self.pools.conns.len)
-  result.nArgs = countQuestionMarks(sql)
+  result.nArgs = result.entry.nArgs
+  result.entry.refCount += 1
+  touchStmtEntry(result.entry)
   result.resultBindCache = newSeq[MysqlResultBindCache](self.pools.conns.len)
 
 
 proc ensurePreparedStmt(self: MysqlPreparedStatement, connI: int): Future[PSTMT] {.async.} =
-  if self.stmts[connI].isNil:
-    self.stmts[connI] = await mysql_impl.prepareStmt(self.owner.pools.conns[connI].conn, self.sql, self.owner.pools.timeout)
-  return self.stmts[connI]
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MySQL prepared statement received an invalid connection index")
+  if self.entry.stmts[connI].isNil:
+    self.entry.stmts[connI] = await mysql_impl.prepareStmt(
+      self.owner.pools.conns[connI].conn,
+      self.sql,
+      self.owner.pools.timeout
+    )
+  touchStmtEntry(self.entry)
+  return self.entry.stmts[connI]
 
 
-proc getPreparedRows(self: MysqlPreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
-  var connI = self.owner.transactionConn
-  if not self.owner.isInTransaction:
-    connI = getFreeConn(self.owner).await
-  defer:
-    if not self.owner.isInTransaction:
-      self.owner.returnConn(connI).await
-  if connI == errorConnectionNum:
-    raisePoolTimeout(self)
+proc getPreparedRowsOnConn(
+  self: MysqlPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MySQL prepared statement received an invalid connection index")
 
   let stmt = await self.ensurePreparedStmt(connI)
   if connI >= self.resultBindCache.len:
@@ -651,6 +720,28 @@ proc getPreparedRows(self: MysqlPreparedStatement, args: seq[PreparedParam]): Fu
     self.owner.pools.timeout,
     self.resultBindCache[connI]
   ).await
+
+
+proc getPreparedRows(self: MysqlPreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
+  var connI = self.owner.transactionConn
+  if not self.owner.isInTransaction:
+    connI = getFreeConn(self.owner).await
+  defer:
+    if not self.owner.isInTransaction:
+      self.owner.returnConn(connI).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+
+  return await self.getPreparedRowsOnConn(connI, args)
+
+
+proc getPreparedRows(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.verifyCtx(ctx)
+  return await self.getPreparedRowsOnConn(ctx.connI, args)
 
 
 proc getPreparedAllRows(self: MysqlPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
@@ -682,6 +773,69 @@ proc getPreparedRowPlain(self: MysqlPreparedStatement, args: seq[PreparedParam])
   return rows[0]
 
 
+proc getPreparedAllRows(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[JsonNode](0)
+  return toJson(rows, dbRows)
+
+
+proc getPreparedRow(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return none(JsonNode)
+  return toJson(rows, dbRows)[0].some()
+
+
+proc getPreparedAllRowsPlain(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  let (rows, _) = await self.getPreparedRows(ctx, args)
+  return rows
+
+
+proc getPreparedRowPlain(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  let (rows, _) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[string](0)
+  return rows[0]
+
+
+proc execPreparedOnConn(
+  self: MysqlPreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "MySQL prepared statement received an invalid connection index")
+
+  let stmt = await self.ensurePreparedStmt(connI)
+  await mysql_impl.execPreparedStmt(
+    self.owner.pools.conns[connI].conn,
+    stmt,
+    args,
+    self.owner.pools.timeout
+  )
+
+
 proc execPrepared(self: MysqlPreparedStatement, args: seq[PreparedParam]) {.async.} =
   var connI = self.owner.transactionConn
   if not self.owner.isInTransaction:
@@ -692,13 +846,16 @@ proc execPrepared(self: MysqlPreparedStatement, args: seq[PreparedParam]) {.asyn
   if connI == errorConnectionNum:
     raisePoolTimeout(self)
 
-  let stmt = await self.ensurePreparedStmt(connI)
-  await mysql_impl.execPreparedStmt(
-    self.owner.pools.conns[connI].conn,
-    stmt,
-    args,
-    self.owner.pools.timeout
-  )
+  await self.execPreparedOnConn(connI, args)
+
+
+proc execPrepared(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.verifyCtx(ctx)
+  await self.execPreparedOnConn(ctx.connI, args)
 
 
 proc preparedGet(self: MysqlPreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
@@ -751,49 +908,185 @@ proc preparedExec(self: MysqlPreparedStatement, args: seq[PreparedParam]) {.asyn
     raise getCurrentException()
 
 
+proc preparedGet(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedAllRows(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedFirst(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedGetPlain(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedAllRowsPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedFirstPlain(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRowPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedExec(
+  self: MysqlPreparedStatement,
+  ctx: MysqlPreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
 proc get*(self: MysqlPreparedStatement, args: seq[string]): Future[seq[JsonNode]] {.async.} =
   return await self.preparedGet(args.toPreparedParams)
+
+
+proc get*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: seq[string]): Future[seq[JsonNode]] {.async.} =
+  return await self.preparedGet(ctx, args.toPreparedParams)
 
 
 proc get*(self: MysqlPreparedStatement, args: JsonNode): Future[seq[JsonNode]] {.async.} =
   return await self.preparedGet(args.toPreparedParams)
 
 
+proc get*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  return await self.preparedGet(ctx, args.toPreparedParams)
+
+
 proc first*(self: MysqlPreparedStatement, args: seq[string]): Future[Option[JsonNode]] {.async.} =
   return await self.preparedFirst(args.toPreparedParams)
+
+
+proc first*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: seq[string]): Future[Option[JsonNode]] {.async.} =
+  return await self.preparedFirst(ctx, args.toPreparedParams)
 
 
 proc first*(self: MysqlPreparedStatement, args: JsonNode): Future[Option[JsonNode]] {.async.} =
   return await self.preparedFirst(args.toPreparedParams)
 
 
+proc first*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  return await self.preparedFirst(ctx, args.toPreparedParams)
+
+
 proc getPlain*(self: MysqlPreparedStatement, args: seq[string]): Future[seq[seq[string]]] {.async.} =
   return await self.preparedGetPlain(args.toPreparedParams)
+
+
+proc getPlain*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: seq[string]): Future[seq[seq[string]]] {.async.} =
+  return await self.preparedGetPlain(ctx, args.toPreparedParams)
 
 
 proc getPlain*(self: MysqlPreparedStatement, args: JsonNode): Future[seq[seq[string]]] {.async.} =
   return await self.preparedGetPlain(args.toPreparedParams)
 
 
+proc getPlain*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: JsonNode): Future[seq[seq[string]]] {.async.} =
+  return await self.preparedGetPlain(ctx, args.toPreparedParams)
+
+
 proc firstPlain*(self: MysqlPreparedStatement, args: seq[string]): Future[seq[string]] {.async.} =
   return await self.preparedFirstPlain(args.toPreparedParams)
+
+
+proc firstPlain*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: seq[string]): Future[seq[string]] {.async.} =
+  return await self.preparedFirstPlain(ctx, args.toPreparedParams)
 
 
 proc firstPlain*(self: MysqlPreparedStatement, args: JsonNode): Future[seq[string]] {.async.} =
   return await self.preparedFirstPlain(args.toPreparedParams)
 
 
+proc firstPlain*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: JsonNode): Future[seq[string]] {.async.} =
+  return await self.preparedFirstPlain(ctx, args.toPreparedParams)
+
+
 proc exec*(self: MysqlPreparedStatement, args: seq[string]) {.async.} =
   await self.preparedExec(args.toPreparedParams)
+
+
+proc exec*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: seq[string]) {.async.} =
+  await self.preparedExec(ctx, args.toPreparedParams)
 
 
 proc exec*(self: MysqlPreparedStatement, args: JsonNode) {.async.} =
   await self.preparedExec(args.toPreparedParams)
 
 
+proc exec*(self: MysqlPreparedStatement, ctx: MysqlPreparedContext, args: JsonNode) {.async.} =
+  await self.preparedExec(ctx, args.toPreparedParams)
+
+
 proc close*(self: MysqlPreparedStatement) {.async.} =
-  for stmt in self.stmts:
-    mysql_impl.closePreparedStmt(stmt)
+  if self.isNil or self.isClosed:
+    return
+  self.isClosed = true
+  if not self.entry.isNil:
+    if self.entry.refCount > 0:
+      self.entry.refCount -= 1
+    touchStmtEntry(self.entry)
+
+
+proc flushStmt*(self: MysqlConnections, sql: string) {.async.} =
+  if not hasPreparedEntry(self.pools.preparedCache, sql):
+    return
+  let entry = self.pools.preparedCache[sql]
+  for i, stmt in entry.stmts:
+    if stmt.isNil:
+      continue
+    try:
+      mysql_impl.closePreparedStmt(stmt)
+    except CatchableError:
+      self.log.echoErrorMsg("close failed for prepared stmt: " & getCurrentExceptionMsg())
+    entry.stmts[i] = nil
+  self.pools.preparedCache.del(sql)
+
+
+proc clearStmtCache*(self: MysqlConnections) {.async.} =
+  let keys = toSeq(self.pools.preparedCache.keys)
+  for sql in keys:
+    await self.flushStmt(sql)
 
 
 proc get*(self: RawMysqlQuery):Future[seq[JsonNode]] {.async.} =

--- a/src/allographer/query_builder/models/mysql/mysql_open.nim
+++ b/src/allographer/query_builder/models/mysql/mysql_open.nim
@@ -1,3 +1,4 @@
+import std/tables
 import std/times
 import ../../libs/database_url
 import ../../libs/mysql/mysql_rdb
@@ -33,7 +34,8 @@ proc dbOpen*(_:type MySQL, database: string, user: string, password: string,
     )
   let pools = Connections(
     conns: conns,
-    timeout: timeout
+    timeout: timeout,
+    preparedCache: initTable[string, MysqlPreparedEntry](),
   )
   let info = ConnectionInfo(
     database:database,

--- a/src/allographer/query_builder/models/mysql/mysql_types.nim
+++ b/src/allographer/query_builder/models/mysql/mysql_types.nim
@@ -1,3 +1,4 @@
+import std/tables
 import std/json
 import ../../log
 import ../../libs/mysql/mysql_rdb
@@ -20,9 +21,18 @@ type Connection* = object
   createdAt*: int64
 
 
+type MysqlPreparedEntry* = ref object
+  sql*: string
+  nArgs*: int
+  stmts*: seq[PSTMT]
+  refCount*: int
+  lastUsedAt*: int64
+
+
 type Connections* = ref object
   conns*: seq[Connection]
   timeout*:int
+  preparedCache*: Table[string, MysqlPreparedEntry]
 
 
 ## created by `let rdb = dbOpen(MySQL, "localhost", 3306)`
@@ -33,6 +43,11 @@ type MysqlConnections* = ref object
   # for transaction
   isInTransaction*: bool
   transactionConn*: int
+
+
+type MysqlPreparedContext* = ref object
+  owner*: MysqlConnections
+  connI*: int
 
 
 ## created by `rdb.select("columnName")` or `rdb.table("tableName")`
@@ -71,9 +86,10 @@ type MysqlResultBindCache* = ref object
 type MysqlPreparedStatement* = ref object
   owner*: MysqlConnections
   info*: ConnectionInfo
+  entry*: MysqlPreparedEntry
   sql*: string
-  stmts*: seq[PSTMT]
   nArgs*: int
+  isClosed*: bool
   resultBindCache*: seq[MysqlResultBindCache]
 
 

--- a/src/allographer/query_builder/models/sqlite/sqlite_exec.nim
+++ b/src/allographer/query_builder/models/sqlite/sqlite_exec.nim
@@ -80,19 +80,86 @@ proc raisePoolTimeout(self: SqliteConnections | SqliteQuery | RawSqliteQuery | S
   raise newException(DbError, "Timed out while waiting for a free SQLite connection")
 
 
-proc prepare*(self: SqliteConnections, sql: string): SqlitePreparedStatement =
-  SqlitePreparedStatement(
-    owner: self,
+proc touchStmtEntry(entry: SqlitePreparedEntry) =
+  entry.lastUsedAt = getTime().toUnix()
+
+
+proc mustBeOpen(self: SqlitePreparedStatement) =
+  if self.isNil or self.isClosed:
+    raise newException(DbError, "SQLite prepared statement is already closed")
+
+
+proc hasPreparedEntry(cache: Table[string, SqlitePreparedEntry], sql: string): bool =
+  for key in cache.keys:
+    if key == sql:
+      return true
+  return false
+
+
+proc getStmtEntry(self: SqliteConnections, sql: string): SqlitePreparedEntry =
+  if hasPreparedEntry(self.pools.preparedCache, sql):
+    return self.pools.preparedCache[sql]
+  let entry = SqlitePreparedEntry(
     sql: sql,
+    nArgs: countQuestionMarks(sql),
     stmts: newSeq[PStmt](self.pools.conns.len),
-    nArgs: countQuestionMarks(sql)
+    refCount: 0,
+    lastUsedAt: getTime().toUnix(),
   )
+  self.pools.preparedCache[sql] = entry
+  return entry
+
+
+proc prepare*(self: SqliteConnections, sql: string): SqlitePreparedStatement =
+  new(result)
+  result.owner = self
+  result.entry = self.getStmtEntry(sql)
+  result.sql = sql
+  result.entry.refCount += 1
+  touchStmtEntry(result.entry)
 
 
 proc ensurePreparedStmt(self: SqlitePreparedStatement, connI: int): Future[PStmt] {.async.} =
-  if self.stmts[connI].isNil:
-    self.stmts[connI] = sqlite_impl.prepare(self.owner.pools.conns[connI].conn, self.sql, self.owner.pools.timeout).await
-  return self.stmts[connI]
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SQLite prepared statement received an invalid connection index")
+  if self.entry.stmts[connI].isNil:
+    self.entry.stmts[connI] = sqlite_impl.prepare(
+      self.owner.pools.conns[connI].conn,
+      self.sql,
+      self.owner.pools.timeout
+    ).await
+  touchStmtEntry(self.entry)
+  return self.entry.stmts[connI]
+
+
+proc withConn*(
+  self: SqliteConnections,
+  body: proc (ctx: SqlitePreparedContext): Future[void]
+) {.async.} =
+  if self.isInTransaction:
+    let ctx = SqlitePreparedContext(owner: self, connI: self.transactionConn)
+    await body(ctx)
+    return
+
+  let connI = getFreeConn(self).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  defer:
+    self.returnConn(connI).await
+
+  let ctx = SqlitePreparedContext(owner: self, connI: connI)
+  await body(ctx)
+
+
+proc verifyCtx(self: SqlitePreparedStatement, ctx: SqlitePreparedContext) =
+  self.mustBeOpen()
+  if ctx.isNil:
+    raise newException(DbError, "SQLite prepared context is nil")
+  if ctx.owner != self.owner:
+    raise newException(DbError, "SQLite prepared context owner mismatch")
+  if ctx.connI < 0 or ctx.connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SQLite prepared context has invalid connection index")
 
 
 
@@ -532,15 +599,14 @@ proc transactionEnd(self:SqliteConnections, query:string) {.async.} =
   sqlite_impl.exec(self.pools.conns[self.transactionConn].conn, query, newJArray(), self.pools.timeout).await
 
 
-proc getPreparedRows(self: SqlitePreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
-  var connI = self.owner.transactionConn
-  if not self.owner.isInTransaction:
-    connI = getFreeConn(self.owner).await
-  defer:
-    if not self.owner.isInTransaction:
-      self.owner.returnConn(connI).await
-  if connI == errorConnectionNum:
-    raisePoolTimeout(self)
+proc getPreparedRowsOnConn(
+  self: SqlitePreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SQLite prepared statement received an invalid connection index")
 
   let stmt = await self.ensurePreparedStmt(connI)
   if not self.hasCachedColumns:
@@ -554,6 +620,28 @@ proc getPreparedRows(self: SqlitePreparedStatement, args: seq[PreparedParam]): F
     self.owner.pools.timeout,
     self.cachedColumns
   ).await
+
+
+proc getPreparedRows(self: SqlitePreparedStatement, args: seq[PreparedParam]): Future[(seq[seq[string]], DbRows)] {.async.} =
+  var connI = self.owner.transactionConn
+  if not self.owner.isInTransaction:
+    connI = getFreeConn(self.owner).await
+  defer:
+    if not self.owner.isInTransaction:
+      self.owner.returnConn(connI).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+
+  return await self.getPreparedRowsOnConn(connI, args)
+
+
+proc getPreparedRows(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[(seq[seq[string]], DbRows)] {.async.} =
+  self.verifyCtx(ctx)
+  return await self.getPreparedRowsOnConn(ctx.connI, args)
 
 
 proc getPreparedAllRows(self: SqlitePreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
@@ -585,6 +673,69 @@ proc getPreparedRowPlain(self: SqlitePreparedStatement, args: seq[PreparedParam]
   return rows[0]
 
 
+proc getPreparedAllRows(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[JsonNode](0)
+  return toJson(rows, dbRows)
+
+
+proc getPreparedRow(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  let (rows, dbRows) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return none(JsonNode)
+  return toJson(rows, dbRows)[0].some()
+
+
+proc getPreparedAllRowsPlain(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  let (rows, _) = await self.getPreparedRows(ctx, args)
+  return rows
+
+
+proc getPreparedRowPlain(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  let (rows, _) = await self.getPreparedRows(ctx, args)
+  if rows.len == 0:
+    self.owner.log.echoErrorMsg(self.sql)
+    return newSeq[string](0)
+  return rows[0]
+
+
+proc execPreparedOnConn(
+  self: SqlitePreparedStatement,
+  connI: int,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SQLite prepared statement received an invalid connection index")
+
+  let stmt = await self.ensurePreparedStmt(connI)
+  await sqlite_impl.preparedExecReuse(
+    self.owner.pools.conns[connI].conn,
+    stmt,
+    args,
+    self.owner.pools.timeout
+  )
+
+
 proc execPrepared(self: SqlitePreparedStatement, args: seq[PreparedParam]) {.async.} =
   var connI = self.owner.transactionConn
   if not self.owner.isInTransaction:
@@ -595,13 +746,16 @@ proc execPrepared(self: SqlitePreparedStatement, args: seq[PreparedParam]) {.asy
   if connI == errorConnectionNum:
     raisePoolTimeout(self)
 
-  let stmt = await self.ensurePreparedStmt(connI)
-  await sqlite_impl.preparedExecReuse(
-    self.owner.pools.conns[connI].conn,
-    stmt,
-    args,
-    self.owner.pools.timeout
-  )
+  await self.execPreparedOnConn(connI, args)
+
+
+proc execPrepared(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  self.verifyCtx(ctx)
+  await self.execPreparedOnConn(ctx.connI, args)
 
 
 proc preparedGet(self: SqlitePreparedStatement, args: seq[PreparedParam]): Future[seq[JsonNode]] {.async.} =
@@ -648,6 +802,76 @@ proc preparedExec(self: SqlitePreparedStatement, args: seq[PreparedParam]) {.asy
   try:
     self.owner.log.logger(self.sql)
     await self.execPrepared(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedGet(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedAllRows(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedFirst(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedGetPlain(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[seq[string]]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedAllRowsPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedFirstPlain(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+): Future[seq[string]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRowPlain(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc preparedExec(
+  self: SqlitePreparedStatement,
+  ctx: SqlitePreparedContext,
+  args: seq[PreparedParam]
+) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(ctx, args)
   except CatchableError:
     self.owner.log.echoErrorMsg(self.sql)
     self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
@@ -933,14 +1157,34 @@ proc firstPlain*(self: RawSqliteQuery):Future[seq[string]] {.async.} =
 
 
 proc close*(self: SqlitePreparedStatement) {.async.} =
-  for i, stmt in self.stmts:
+  if self.isNil or self.isClosed:
+    return
+  self.isClosed = true
+  if not self.entry.isNil:
+    if self.entry.refCount > 0:
+      self.entry.refCount -= 1
+    touchStmtEntry(self.entry)
+
+
+proc flushStmt*(self: SqliteConnections, sql: string) {.async.} =
+  if not hasPreparedEntry(self.pools.preparedCache, sql):
+    return
+  let entry = self.pools.preparedCache[sql]
+  for i, stmt in entry.stmts:
     if stmt.isNil:
       continue
     try:
       discard finalize(stmt)
     except CatchableError:
-      self.owner.log.echoErrorMsg("finalize failed for prepared stmt: " & getCurrentExceptionMsg())
-    self.stmts[i] = nil
+      self.log.echoErrorMsg("finalize failed for prepared stmt: " & getCurrentExceptionMsg())
+    entry.stmts[i] = nil
+  self.pools.preparedCache.del(sql)
+
+
+proc clearStmtCache*(self: SqliteConnections) {.async.} =
+  let keys = toSeq(self.pools.preparedCache.keys)
+  for sql in keys:
+    await self.flushStmt(sql)
 
 
 # ================================================================================
@@ -951,40 +1195,80 @@ proc get*(self: SqlitePreparedStatement, args: seq[string]): Future[seq[JsonNode
   return await self.preparedGet(args.toPreparedParams)
 
 
+proc get*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: seq[string]): Future[seq[JsonNode]] {.async.} =
+  return await self.preparedGet(ctx, args.toPreparedParams)
+
+
 proc get*(self: SqlitePreparedStatement, args: JsonNode): Future[seq[JsonNode]] {.async.} =
   return await self.preparedGet(args.toPreparedParams)
+
+
+proc get*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  return await self.preparedGet(ctx, args.toPreparedParams)
 
 
 proc first*(self: SqlitePreparedStatement, args: seq[string]): Future[Option[JsonNode]] {.async.} =
   return await self.preparedFirst(args.toPreparedParams)
 
 
+proc first*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: seq[string]): Future[Option[JsonNode]] {.async.} =
+  return await self.preparedFirst(ctx, args.toPreparedParams)
+
+
 proc first*(self: SqlitePreparedStatement, args: JsonNode): Future[Option[JsonNode]] {.async.} =
   return await self.preparedFirst(args.toPreparedParams)
+
+
+proc first*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  return await self.preparedFirst(ctx, args.toPreparedParams)
 
 
 proc getPlain*(self: SqlitePreparedStatement, args: seq[string]): Future[seq[seq[string]]] {.async.} =
   return await self.preparedGetPlain(args.toPreparedParams)
 
 
+proc getPlain*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: seq[string]): Future[seq[seq[string]]] {.async.} =
+  return await self.preparedGetPlain(ctx, args.toPreparedParams)
+
+
 proc getPlain*(self: SqlitePreparedStatement, args: JsonNode): Future[seq[seq[string]]] {.async.} =
   return await self.preparedGetPlain(args.toPreparedParams)
+
+
+proc getPlain*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: JsonNode): Future[seq[seq[string]]] {.async.} =
+  return await self.preparedGetPlain(ctx, args.toPreparedParams)
 
 
 proc firstPlain*(self: SqlitePreparedStatement, args: seq[string]): Future[seq[string]] {.async.} =
   return await self.preparedFirstPlain(args.toPreparedParams)
 
 
+proc firstPlain*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: seq[string]): Future[seq[string]] {.async.} =
+  return await self.preparedFirstPlain(ctx, args.toPreparedParams)
+
+
 proc firstPlain*(self: SqlitePreparedStatement, args: JsonNode): Future[seq[string]] {.async.} =
   return await self.preparedFirstPlain(args.toPreparedParams)
+
+
+proc firstPlain*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: JsonNode): Future[seq[string]] {.async.} =
+  return await self.preparedFirstPlain(ctx, args.toPreparedParams)
 
 
 proc exec*(self: SqlitePreparedStatement, args: seq[string]) {.async.} =
   await self.preparedExec(args.toPreparedParams)
 
 
+proc exec*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: seq[string]) {.async.} =
+  await self.preparedExec(ctx, args.toPreparedParams)
+
+
 proc exec*(self: SqlitePreparedStatement, args: JsonNode) {.async.} =
   await self.preparedExec(args.toPreparedParams)
+
+
+proc exec*(self: SqlitePreparedStatement, ctx: SqlitePreparedContext, args: JsonNode) {.async.} =
+  await self.preparedExec(ctx, args.toPreparedParams)
 
 
 

--- a/src/allographer/query_builder/models/sqlite/sqlite_open.nim
+++ b/src/allographer/query_builder/models/sqlite/sqlite_open.nim
@@ -25,6 +25,7 @@ proc openSqlite(database: string; maxConnections: int; timeout: int;
     timeout: timeout,
     waiters: initDeque[Future[void]](),
     columnTypeCache: initTable[string, seq[(string, string)]](),
+    preparedCache: initTable[string, SqlitePreparedEntry](),
   )
   result = SqliteConnections(
     pools: pools,

--- a/src/allographer/query_builder/models/sqlite/sqlite_types.nim
+++ b/src/allographer/query_builder/models/sqlite/sqlite_types.nim
@@ -16,6 +16,14 @@ type Connection* = ref object
   createdAt*: int64
 
 
+type SqlitePreparedEntry* = ref object
+  sql*: string
+  nArgs*: int
+  stmts*: seq[PStmt]
+  refCount*: int
+  lastUsedAt*: int64
+
+
 type Connections* = ref object
   conns*: seq[Connection]
   timeout*: int
@@ -23,6 +31,7 @@ type Connections* = ref object
   waiters*: Deque[Future[void]]
   ## `exec` / `insertId` 用。テーブルごとに PRAGMA table_info の結果を初回のみ保持する。
   columnTypeCache*: Table[string, seq[(string, string)]]
+  preparedCache*: Table[string, SqlitePreparedEntry]
 
 
 ## created by `let rdb = dbOpen(SQLite3, "/path/to/sqlite.db")`
@@ -32,6 +41,11 @@ type SqliteConnections* = ref object
   # for transaction
   isInTransaction*: bool
   transactionConn*: int
+
+
+type SqlitePreparedContext* = ref object
+  owner*: SqliteConnections
+  connI*: int
 
 
 ## created by `rdb.select("columnName")` or `rdb.table("tableName")`
@@ -59,9 +73,9 @@ type RawSqliteQuery* = ref object
 
 type SqlitePreparedStatement* = ref object
   owner*: SqliteConnections
+  entry*: SqlitePreparedEntry
   sql*: string
-  stmts*: seq[PStmt]
-  nArgs*: int
+  isClosed*: bool
   cachedColumns*: DbColumns
   hasCachedColumns*: bool
 

--- a/src/allographer/query_builder/models/surreal/surreal_exec.nim
+++ b/src/allographer/query_builder/models/surreal/surreal_exec.nim
@@ -3,14 +3,18 @@ import std/deques
 import std/json
 import std/monotimes
 import std/options
+import std/sequtils
 import std/strformat
 import std/strutils
+import std/tables
 import std/times
+import ../../error
 import ../../libs/surreal/surreal_lib
 import ../../libs/surreal/surreal_impl
 import ../../log
 import ../../enums
 import ../database_types
+import ../../prepared_param
 import ./query/surreal_builder
 import ./surreal_types
 import ./surreal_query
@@ -72,6 +76,182 @@ proc returnConn(self: SurrealConnections | SurrealQuery | RawSurrealQuery, i: in
   if i != errorConnectionNum:
     self.pools.conns[i].isBusy = false
     wakeOnePoolWaiter(self.pools)
+
+
+proc raisePoolTimeout(self: SurrealConnections | SurrealQuery | RawSurrealQuery | SurrealPreparedStatement) {.noreturn.} =
+  raise newException(DbError, "Timed out while waiting for a free SurrealDB connection")
+
+
+proc touchStmtEntry(entry: SurrealPreparedEntry) =
+  entry.lastUsedAt = getTime().toUnix()
+
+
+proc mustBeOpen(self: SurrealPreparedStatement) =
+  if self.isNil or self.owner.isNil or self.isClosed:
+    raise newException(DbError, "SurrealDB prepared statement is already closed")
+
+
+proc hasPreparedEntry(cache: Table[string, SurrealPreparedEntry], sql: string): bool =
+  for key in cache.keys:
+    if key == sql:
+      return true
+  return false
+
+
+proc getStmtEntry(self: SurrealConnections, sql: string): SurrealPreparedEntry =
+  if hasPreparedEntry(self.pools.preparedCache, sql):
+    return self.pools.preparedCache[sql]
+  let entry = SurrealPreparedEntry(
+    sql: sql,
+    normalizedSql: sql.questionToDaller(),
+    nArgs: countQuestionMarks(sql),
+    refCount: 0,
+    lastUsedAt: getTime().toUnix(),
+  )
+  self.pools.preparedCache[sql] = entry
+  return entry
+
+
+proc prepare*(self: SurrealConnections, sql: string): SurrealPreparedStatement =
+  let entry = self.getStmtEntry(sql)
+  entry.refCount += 1
+  touchStmtEntry(entry)
+  new(result)
+  result.owner = self
+  result.entry = entry
+  result.sql = sql
+  result.nArgs = entry.nArgs
+  result.isClosed = false
+
+
+proc withConn*(
+  self: SurrealConnections,
+  body: proc (ctx: SurrealPreparedContext): Future[void]
+) {.async.} =
+  let connI = getFreeConn(self).await
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  defer:
+    self.returnConn(connI).await
+
+  let ctx = SurrealPreparedContext(owner: self, connI: connI)
+  await body(ctx)
+
+
+proc verifyCtx(self: SurrealPreparedStatement, ctx: SurrealPreparedContext) =
+  self.mustBeOpen()
+  if ctx.isNil:
+    raise newException(DbError, "SurrealDB prepared context is nil")
+  if ctx.owner.isNil or ctx.owner != self.owner:
+    raise newException(DbError, "SurrealDB prepared context owner mismatch")
+  if ctx.connI < 0 or ctx.connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SurrealDB prepared context has invalid connection index")
+
+
+proc toPreparedArgsJson(args: seq[string]): JsonNode =
+  result = newJArray()
+  for arg in args:
+    if arg == "NULL" or arg == "null":
+      result.add(newJNull())
+    else:
+      result.add(%arg)
+
+
+proc buildPreparedSql(self: SurrealPreparedStatement, args: JsonNode): string =
+  self.mustBeOpen()
+  touchStmtEntry(self.entry)
+  result = dbFormatPrepared(self.entry.normalizedSql, args)
+
+
+proc getPreparedRowsOnConn(
+  self: SurrealPreparedStatement,
+  connI: int,
+  args: JsonNode
+): Future[seq[JsonNode]] {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SurrealDB prepared statement received an invalid connection index")
+
+  let sql = self.buildPreparedSql(args)
+  let rows = surreal_impl.query(
+    self.owner.pools.conns[connI].conn,
+    sql,
+    newJArray(),
+    self.owner.pools.timeout
+  ).await
+
+  if rows.kind != JArray or rows.len == 0:
+    return newSeq[JsonNode](0)
+  return rows.getElems()
+
+
+proc getPreparedRowOnConn(
+  self: SurrealPreparedStatement,
+  connI: int,
+  args: JsonNode
+): Future[Option[JsonNode]] {.async.} =
+  let rows = await self.getPreparedRowsOnConn(connI, args)
+  if rows.len == 0:
+    return none(JsonNode)
+  return rows[0].some
+
+
+proc execPreparedOnConn(
+  self: SurrealPreparedStatement,
+  connI: int,
+  args: JsonNode
+) {.async.} =
+  self.mustBeOpen()
+  if connI < 0 or connI >= self.owner.pools.conns.len:
+    raise newException(DbError, "SurrealDB prepared statement received an invalid connection index")
+
+  let sql = self.buildPreparedSql(args)
+  await surreal_impl.exec(
+    self.owner.pools.conns[connI].conn,
+    sql,
+    newJArray(),
+    self.owner.pools.timeout
+  )
+
+
+proc getPreparedRows(self: SurrealPreparedStatement, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  let connI = await getFreeConn(self.owner)
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  defer:
+    await self.owner.returnConn(connI)
+  return await self.getPreparedRowsOnConn(connI, args)
+
+
+proc getPreparedRows(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  self.verifyCtx(ctx)
+  return await self.getPreparedRowsOnConn(ctx.connI, args)
+
+
+proc getPreparedRow(self: SurrealPreparedStatement, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  let rows = await self.getPreparedRows(args)
+  if rows.len == 0:
+    return none(JsonNode)
+  return rows[0].some
+
+
+proc getPreparedRow(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  self.verifyCtx(ctx)
+  return await self.getPreparedRowOnConn(ctx.connI, args)
+
+
+proc execPrepared(self: SurrealPreparedStatement, args: JsonNode) {.async.} =
+  let connI = await getFreeConn(self.owner)
+  if connI == errorConnectionNum:
+    raisePoolTimeout(self)
+  defer:
+    await self.owner.returnConn(connI)
+  await self.execPreparedOnConn(connI, args)
+
+
+proc execPrepared(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: JsonNode) {.async.} =
+  self.verifyCtx(ctx)
+  await self.execPreparedOnConn(ctx.connI, args)
 
 
 # ================================================================================
@@ -314,6 +494,163 @@ proc column(self:SurrealQuery, queryString:string):Future[JsonNode] {.async.} =
       strArgs.add(arg["value"].pretty)
 
   return surreal_impl.info(self.pools.conns[connI].conn, queryString, strArgs, self.pools.timeout).await
+
+
+# ================================================================================
+# prepared statement cache
+# ================================================================================
+
+proc close*(self: SurrealPreparedStatement) {.async.} =
+  if self.isNil or self.isClosed:
+    return
+  self.isClosed = true
+  if not self.entry.isNil and self.entry.refCount > 0:
+    self.entry.refCount -= 1
+    touchStmtEntry(self.entry)
+
+
+proc removePreparedEntry(self: SurrealConnections, sql: string) =
+  if not self.pools.preparedCache.hasKey(sql):
+    return
+  self.pools.preparedCache.del(sql)
+
+
+proc flushStmt*(self: SurrealConnections, stmt: SurrealPreparedStatement) {.async.} =
+  if stmt.isNil:
+    return
+  let sql = stmt.sql
+  await stmt.close()
+  self.removePreparedEntry(sql)
+
+
+proc clearStmtCache*(self: SurrealConnections) {.async.} =
+  let keys = toSeq(self.pools.preparedCache.keys)
+  for sql in keys:
+    self.removePreparedEntry(sql)
+
+
+# ================================================================================
+# public prepared exec
+# ================================================================================
+
+proc get*(self: SurrealPreparedStatement, args: seq[string]): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRows(toPreparedArgsJson(args))
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc get*(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: seq[string]): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRows(ctx, toPreparedArgsJson(args))
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc get*(self: SurrealPreparedStatement, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRows(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc get*(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: JsonNode): Future[seq[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRows(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc first*(self: SurrealPreparedStatement, args: seq[string]): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(toPreparedArgsJson(args))
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc first*(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: seq[string]): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(ctx, toPreparedArgsJson(args))
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc first*(self: SurrealPreparedStatement, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc first*(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: JsonNode): Future[Option[JsonNode]] {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    return await self.getPreparedRow(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc exec*(self: SurrealPreparedStatement, args: seq[string]) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(toPreparedArgsJson(args))
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc exec*(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: seq[string]) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(ctx, toPreparedArgsJson(args))
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc exec*(self: SurrealPreparedStatement, args: JsonNode) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
+
+
+proc exec*(self: SurrealPreparedStatement, ctx: SurrealPreparedContext, args: JsonNode) {.async.} =
+  try:
+    self.owner.log.logger(self.sql)
+    await self.execPrepared(ctx, args)
+  except CatchableError:
+    self.owner.log.echoErrorMsg(self.sql)
+    self.owner.log.echoErrorMsg(getCurrentExceptionMsg())
+    raise getCurrentException()
 
 
 # proc transactionStart(self:SurrealConnections) {.async.} =

--- a/src/allographer/query_builder/models/surreal/surreal_open.nim
+++ b/src/allographer/query_builder/models/surreal/surreal_open.nim
@@ -4,6 +4,7 @@ import std/httpclient
 import std/httpcore
 import std/strformat
 import std/base64
+import std/tables
 import std/times
 import ../../libs/surreal/surreal_rdb
 import ../../error
@@ -76,6 +77,7 @@ proc dbOpen*(_:type SurrealDB, namespace:string = "", database: string = "", use
     conns: conns,
     timeout: timeout,
     waiters: initDeque[Future[void]](),
+    preparedCache: initTable[string, SurrealPreparedEntry](),
   )
   return SurrealConnections(
     pools: pools,

--- a/src/allographer/query_builder/models/surreal/surreal_types.nim
+++ b/src/allographer/query_builder/models/surreal/surreal_types.nim
@@ -2,6 +2,7 @@ import std/asyncdispatch
 import std/deques
 import std/json
 import std/httpclient
+import std/tables
 import ../../log
 import ../../libs/surreal/surreal_rdb
 import ../../error
@@ -16,17 +17,39 @@ type Connection* = object
   createdAt*:int64
 
 
+type SurrealPreparedEntry* = ref object
+  sql*: string
+  normalizedSql*: string
+  nArgs*: int
+  refCount*: int
+  lastUsedAt*: int64
+
+
 type Connections* = ref object
   conns*: seq[Connection]
   timeout*: int
   ## `getFreeConn` が接続を待つときに積む Future。`returnConn` が先頭から 1 件だけ完了させる。
   waiters*: Deque[Future[void]]
+  preparedCache*: Table[string, SurrealPreparedEntry]
 
 
 ## created by `let rdb = dbOpen(SurrealDB, "ns", "database", "user", "pass", "http://surreal", 8000)`
 type SurrealConnections* = ref object
   log*: LogSetting
   pools*:Connections
+
+
+type SurrealPreparedContext* = ref object
+  owner*: SurrealConnections
+  connI*: int
+
+
+type SurrealPreparedStatement* = ref object
+  owner*: SurrealConnections
+  entry*: SurrealPreparedEntry
+  sql*: string
+  nArgs*: int
+  isClosed*: bool
 
 
 type SurrealQuery* = ref object

--- a/tests/mariadb/test_prepared_statement.nim
+++ b/tests/mariadb/test_prepared_statement.nim
@@ -78,6 +78,44 @@ suite($rdb & " prepared statement"):
     check stmt.firstPlain(args).waitFor[1] == "user1"
 
 
+  test("logical close and clear cache"):
+    let sql = """SELECT `id`, `name`, `email`, `address` FROM `user` WHERE `id` = ?"""
+    let stmt = rdb.prepare(sql)
+    discard waitFor stmt.first(@["1"])
+    waitFor stmt.close()
+
+    let stmt2 = rdb.prepare(sql)
+    defer:
+      waitFor stmt2.close()
+
+    let rowOpt = stmt2.first(@["1"]).waitFor
+    check rowOpt.isSome
+
+    waitFor rdb.clearStmtCache()
+    let stmt3 = rdb.prepare(sql)
+    defer:
+      waitFor stmt3.close()
+    check stmt3.first(@["1"]).waitFor.isSome
+
+
+  test("with prepared connection context"):
+    let selectStmt = rdb.prepare("""SELECT `id`, `name` FROM `user` WHERE `id` = ?""")
+    let updateStmt = rdb.prepare("""UPDATE `user` SET `address` = ? WHERE `id` = ?""")
+    defer:
+      waitFor selectStmt.close()
+      waitFor updateStmt.close()
+
+    waitFor rdb.withConn(
+      proc(ctx: MariadbPreparedContext): Future[void] {.async.} =
+        discard await selectStmt.first(ctx, @["1"])
+        await updateStmt.exec(ctx, @["ctx-address", "1"])
+    )
+
+    let rowOpt = rdb.table("user").find(1).waitFor
+    let row = options.get(rowOpt)
+    check row["address"].getStr == "ctx-address"
+
+
   test("update null"):
     let stmt = rdb.prepare("""UPDATE `user` SET `address` = ? WHERE `id` = ?""")
     defer:

--- a/tests/mysql/test_prepared_statement.nim
+++ b/tests/mysql/test_prepared_statement.nim
@@ -78,6 +78,44 @@ suite($rdb & " prepared statement"):
     check stmt.firstPlain(args).waitFor[1] == "user1"
 
 
+  test("logical close and clear cache"):
+    let sql = """SELECT `id`, `name`, `email`, `address` FROM `user` WHERE `id` = ?"""
+    let stmt = rdb.prepare(sql)
+    discard waitFor stmt.first(@["1"])
+    waitFor stmt.close()
+
+    let stmt2 = rdb.prepare(sql)
+    defer:
+      waitFor stmt2.close()
+
+    let rowOpt = stmt2.first(@["1"]).waitFor
+    check rowOpt.isSome
+
+    waitFor rdb.clearStmtCache()
+    let stmt3 = rdb.prepare(sql)
+    defer:
+      waitFor stmt3.close()
+    check stmt3.first(@["1"]).waitFor.isSome
+
+
+  test("with prepared connection context"):
+    let selectStmt = rdb.prepare("""SELECT `id`, `name` FROM `user` WHERE `id` = ?""")
+    let updateStmt = rdb.prepare("""UPDATE `user` SET `address` = ? WHERE `id` = ?""")
+    defer:
+      waitFor selectStmt.close()
+      waitFor updateStmt.close()
+
+    waitFor rdb.withConn(
+      proc(ctx: MysqlPreparedContext): Future[void] {.async.} =
+        discard await selectStmt.first(ctx, @["1"])
+        await updateStmt.exec(ctx, @["ctx-address", "1"])
+    )
+
+    let rowOpt = rdb.table("user").find(1).waitFor
+    let row = options.get(rowOpt)
+    check row["address"].getStr == "ctx-address"
+
+
   test("update null"):
     let stmt = rdb.prepare("""UPDATE `user` SET `address` = ? WHERE `id` = ?""")
     defer:

--- a/tests/sqlite/test_prepared_statement.nim
+++ b/tests/sqlite/test_prepared_statement.nim
@@ -78,6 +78,44 @@ suite($rdb & " prepared statement"):
     check stmt.firstPlain(args).waitFor[1] == "user1"
 
 
+  test("logical close and clear cache"):
+    let sql = """SELECT "id", "name", "email", "address" FROM "user" WHERE "id" = ?"""
+    let stmt = rdb.prepare(sql)
+    discard waitFor stmt.first(@["1"])
+    waitFor stmt.close()
+
+    let stmt2 = rdb.prepare(sql)
+    defer:
+      waitFor stmt2.close()
+
+    let rowOpt = stmt2.first(@["1"]).waitFor
+    check rowOpt.isSome
+
+    waitFor rdb.clearStmtCache()
+    let stmt3 = rdb.prepare(sql)
+    defer:
+      waitFor stmt3.close()
+    check stmt3.first(@["1"]).waitFor.isSome
+
+
+  test("with prepared connection context"):
+    let selectStmt = rdb.prepare("""SELECT "id", "name" FROM "user" WHERE "id" = ?""")
+    let updateStmt = rdb.prepare("""UPDATE "user" SET "address" = ? WHERE "id" = ?""")
+    defer:
+      waitFor selectStmt.close()
+      waitFor updateStmt.close()
+
+    waitFor rdb.withConn(
+      proc(ctx: SqlitePreparedContext): Future[void] {.async.} =
+        discard await selectStmt.first(ctx, @["1"])
+        await updateStmt.exec(ctx, @["ctx-address", "1"])
+    )
+
+    let rowOpt = rdb.table("user").find(1).waitFor
+    let row = options.get(rowOpt)
+    check row["address"].getStr == "ctx-address"
+
+
   test("update null"):
     let stmt = rdb.prepare("""UPDATE "user" SET "address" = ? WHERE "id" = ?""")
     defer:

--- a/tests/surrealdb/test_prepared_statement.nim
+++ b/tests/surrealdb/test_prepared_statement.nim
@@ -1,0 +1,98 @@
+discard """
+  cmd: "nim c -d:reset $file"
+"""
+
+import std/asyncdispatch
+import std/deques
+import std/json
+import std/tables
+import std/unittest
+import ../../src/allographer/query_builder/libs/surreal/surreal_lib
+import ../../src/allographer/query_builder/libs/surreal/surreal_rdb
+import ../../src/allographer/query_builder/log
+import ../../src/allographer/query_builder/models/surreal/surreal_exec
+import ../../src/allographer/query_builder/models/surreal/surreal_types
+
+
+proc newTestSurreal(): SurrealConnections =
+  let pools = Connections(
+    conns: @[
+      Connection(
+        conn: SurrealConn(),
+        isBusy: false,
+        createdAt: 0,
+      )
+    ],
+    timeout: 30,
+    waiters: initDeque[Future[void]](),
+    preparedCache: initTable[string, SurrealPreparedEntry](),
+  )
+  result = SurrealConnections(
+    log: LogSetting(
+      shouldDisplayLog: false,
+      shouldOutputLogFile: false,
+      logDir: "",
+    ),
+    pools: pools,
+  )
+
+
+suite "SurrealDB prepared statement":
+  test "dbFormatPrepared":
+    var args = newJArray()
+    args.add(%*"user:alice")
+    args.add(%*"2026-04-03T00:00:00Z")
+    args.add(newJNull())
+    let sql = dbFormatPrepared(
+      questionToDaller("""SELECT * FROM "user" WHERE "id" = ? AND "submit_at" >= ? AND "address" IS ?"""),
+      args
+    )
+    check sql ==
+      """LET $a = user:alice; LET $b = <datetime>"2026-04-03T00:00:00Z"; LET $c = NONE; SELECT * FROM "user" WHERE "id" = $a AND "submit_at" >= $b AND "address" IS $c"""
+
+
+  test "prepare cache lifecycle":
+    let rdb = newTestSurreal()
+    let sql = """SELECT * FROM "user" WHERE "id" = ?"""
+
+    let stmt1 = rdb.prepare(sql)
+    check stmt1.nArgs == 1
+    check stmt1.entry.normalizedSql == questionToDaller(sql)
+    check stmt1.entry.refCount == 1
+    check rdb.pools.preparedCache.len == 1
+
+    let stmt2 = rdb.prepare(sql)
+    check stmt2.entry == stmt1.entry
+    check stmt1.entry.refCount == 2
+
+    waitFor stmt1.close()
+    check stmt1.isClosed
+    check stmt1.entry.refCount == 1
+
+    waitFor stmt2.close()
+    check stmt2.isClosed
+    check stmt2.entry.refCount == 0
+
+    let stmt4 = rdb.prepare(sql)
+    check rdb.pools.preparedCache.len == 1
+    waitFor rdb.flushStmt(stmt4)
+    check stmt4.isClosed
+    check rdb.pools.preparedCache.len == 0
+
+    let stmt3 = rdb.prepare(sql)
+    check stmt3.entry != stmt1.entry
+    waitFor stmt3.close()
+    waitFor rdb.clearStmtCache()
+    check rdb.pools.preparedCache.len == 0
+
+
+  test "withConn context":
+    let rdb = newTestSurreal()
+
+    waitFor rdb.withConn(
+      proc(ctx: SurrealPreparedContext): Future[void] {.async.} =
+        check ctx.owner == rdb
+        check ctx.connI == 0
+    )
+
+    check not rdb.pools.conns[0].isBusy


### PR DESCRIPTION
Add prepared statement support across RDB drivers (incl. SurrealDB v3)

### Summary
This PR introduces a unified prepared statement API across SQLite/PostgreSQL/MySQL/MariaDB, including per-pool caching and connection-scoped execution via `withConn` / `*PreparedContext`. It also adds SurrealDB v3 “prepared statement” support by emulating server-side prepare through client-side template reuse: `?` placeholders are normalized into SurrealQL parameters and bound values are emitted as `LET` statements, executed in a single `/sql` request for safe reuse.

Additionally, it improves pool waiter behavior to ensure concurrent requests correctly complete under tight pool limits, and it updates docs, examples/benchmarks, and test coverage accordingly.

### Key changes
- Cross-driver prepared statement API: `prepare`, `get`, `first`, `exec`, `close`, plus cache controls `flushStmt` / `clearStmtCache`
- `withConn` support via `*PreparedContext`, including validation of connection ownership/index
- SurrealDB v3 prepared statements implemented via `LET` + `/sql` multi-statement template expansion
- Pool waiter improvements (notify-based) with new/updated `test_pool_wait` coverage
- Docs and benchmarks updated; new prepared statement tests added for all supported backends

### Test plan
- Run the project’s test suite (including the prepared statement and pool-wait tests for SQLite/PostgreSQL/MySQL/MariaDB/SurrealDB).